### PR TITLE
binlog: add get latest commit ts from cistern

### DIFF
--- a/go-binlog/cistern.pb.go
+++ b/go-binlog/cistern.pb.go
@@ -13,6 +13,8 @@
 		DumpBinlogResp
 		DumpDDLJobsReq
 		DumpDDLJobsResp
+		GetLatestCommitTSReq
+		GetLatestCommitTSResp
 */
 package binlog
 
@@ -90,11 +92,31 @@ func (m *DumpDDLJobsResp) String() string            { return proto.CompactTextS
 func (*DumpDDLJobsResp) ProtoMessage()               {}
 func (*DumpDDLJobsResp) Descriptor() ([]byte, []int) { return fileDescriptorCistern, []int{3} }
 
+type GetLatestCommitTSReq struct {
+}
+
+func (m *GetLatestCommitTSReq) Reset()                    { *m = GetLatestCommitTSReq{} }
+func (m *GetLatestCommitTSReq) String() string            { return proto.CompactTextString(m) }
+func (*GetLatestCommitTSReq) ProtoMessage()               {}
+func (*GetLatestCommitTSReq) Descriptor() ([]byte, []int) { return fileDescriptorCistern, []int{4} }
+
+type GetLatestCommitTSResp struct {
+	// CommitTS specifies the Last binlog commitTS of the TiDB
+	CommitTS int64 `protobuf:"varint,1,opt,name=commitTS,proto3" json:"commitTS,omitempty"`
+}
+
+func (m *GetLatestCommitTSResp) Reset()                    { *m = GetLatestCommitTSResp{} }
+func (m *GetLatestCommitTSResp) String() string            { return proto.CompactTextString(m) }
+func (*GetLatestCommitTSResp) ProtoMessage()               {}
+func (*GetLatestCommitTSResp) Descriptor() ([]byte, []int) { return fileDescriptorCistern, []int{5} }
+
 func init() {
 	proto.RegisterType((*DumpBinlogReq)(nil), "binlog.DumpBinlogReq")
 	proto.RegisterType((*DumpBinlogResp)(nil), "binlog.DumpBinlogResp")
 	proto.RegisterType((*DumpDDLJobsReq)(nil), "binlog.DumpDDLJobsReq")
 	proto.RegisterType((*DumpDDLJobsResp)(nil), "binlog.DumpDDLJobsResp")
+	proto.RegisterType((*GetLatestCommitTSReq)(nil), "binlog.GetLatestCommitTSReq")
+	proto.RegisterType((*GetLatestCommitTSResp)(nil), "binlog.GetLatestCommitTSResp")
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -112,6 +134,8 @@ type CisternClient interface {
 	DumpBinlog(ctx context.Context, in *DumpBinlogReq, opts ...grpc.CallOption) (Cistern_DumpBinlogClient, error)
 	// DumpDDLJobs dumps all history DDL jobs before a specified commitTS
 	DumpDDLJobs(ctx context.Context, in *DumpDDLJobsReq, opts ...grpc.CallOption) (*DumpDDLJobsResp, error)
+	// GetLatestCommitTS returns the Last binlog commitTS of the TiDB
+	GetLatestCommitTS(ctx context.Context, in *GetLatestCommitTSReq, opts ...grpc.CallOption) (*GetLatestCommitTSResp, error)
 }
 
 type cisternClient struct {
@@ -163,6 +187,15 @@ func (c *cisternClient) DumpDDLJobs(ctx context.Context, in *DumpDDLJobsReq, opt
 	return out, nil
 }
 
+func (c *cisternClient) GetLatestCommitTS(ctx context.Context, in *GetLatestCommitTSReq, opts ...grpc.CallOption) (*GetLatestCommitTSResp, error) {
+	out := new(GetLatestCommitTSResp)
+	err := grpc.Invoke(ctx, "/binlog.Cistern/GetLatestCommitTS", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // Server API for Cistern service
 
 type CisternServer interface {
@@ -170,6 +203,8 @@ type CisternServer interface {
 	DumpBinlog(*DumpBinlogReq, Cistern_DumpBinlogServer) error
 	// DumpDDLJobs dumps all history DDL jobs before a specified commitTS
 	DumpDDLJobs(context.Context, *DumpDDLJobsReq) (*DumpDDLJobsResp, error)
+	// GetLatestCommitTS returns the Last binlog commitTS of the TiDB
+	GetLatestCommitTS(context.Context, *GetLatestCommitTSReq) (*GetLatestCommitTSResp, error)
 }
 
 func RegisterCisternServer(s *grpc.Server, srv CisternServer) {
@@ -215,6 +250,24 @@ func _Cistern_DumpDDLJobs_Handler(srv interface{}, ctx context.Context, dec func
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Cistern_GetLatestCommitTS_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetLatestCommitTSReq)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CisternServer).GetLatestCommitTS(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/binlog.Cistern/GetLatestCommitTS",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CisternServer).GetLatestCommitTS(ctx, req.(*GetLatestCommitTSReq))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Cistern_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "binlog.Cistern",
 	HandlerType: (*CisternServer)(nil),
@@ -222,6 +275,10 @@ var _Cistern_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DumpDDLJobs",
 			Handler:    _Cistern_DumpDDLJobs_Handler,
+		},
+		{
+			MethodName: "GetLatestCommitTS",
+			Handler:    _Cistern_GetLatestCommitTS_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{
@@ -341,6 +398,47 @@ func (m *DumpDDLJobsResp) MarshalTo(data []byte) (int, error) {
 	return i, nil
 }
 
+func (m *GetLatestCommitTSReq) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *GetLatestCommitTSReq) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	return i, nil
+}
+
+func (m *GetLatestCommitTSResp) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *GetLatestCommitTSResp) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.CommitTS != 0 {
+		data[i] = 0x8
+		i++
+		i = encodeVarintCistern(data, i, uint64(m.CommitTS))
+	}
+	return i, nil
+}
+
 func encodeFixed64Cistern(data []byte, offset int, v uint64) int {
 	data[offset] = uint8(v)
 	data[offset+1] = uint8(v >> 8)
@@ -411,6 +509,21 @@ func (m *DumpDDLJobsResp) Size() (n int) {
 			l = len(b)
 			n += 1 + l + sovCistern(uint64(l))
 		}
+	}
+	return n
+}
+
+func (m *GetLatestCommitTSReq) Size() (n int) {
+	var l int
+	_ = l
+	return n
+}
+
+func (m *GetLatestCommitTSResp) Size() (n int) {
+	var l int
+	_ = l
+	if m.CommitTS != 0 {
+		n += 1 + sovCistern(uint64(m.CommitTS))
 	}
 	return n
 }
@@ -776,6 +889,125 @@ func (m *DumpDDLJobsResp) Unmarshal(data []byte) error {
 	}
 	return nil
 }
+func (m *GetLatestCommitTSReq) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowCistern
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetLatestCommitTSReq: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetLatestCommitTSReq: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipCistern(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthCistern
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetLatestCommitTSResp) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowCistern
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetLatestCommitTSResp: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetLatestCommitTSResp: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CommitTS", wireType)
+			}
+			m.CommitTS = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCistern
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				m.CommitTS |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipCistern(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthCistern
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func skipCistern(data []byte) (n int, err error) {
 	l := len(data)
 	iNdEx := 0
@@ -884,7 +1116,7 @@ var (
 func init() { proto.RegisterFile("cistern.proto", fileDescriptorCistern) }
 
 var fileDescriptorCistern = []byte{
-	// 257 bytes of a gzipped FileDescriptorProto
+	// 308 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x09, 0x6e, 0x88, 0x02, 0xff, 0xe2, 0xe2, 0x4d, 0xce, 0x2c, 0x2e,
 	0x49, 0x2d, 0xca, 0xd3, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x62, 0x4b, 0xca, 0xcc, 0xcb, 0xc9,
 	0x4f, 0x97, 0x12, 0x49, 0xcf, 0x4f, 0xcf, 0x07, 0x0b, 0xe9, 0x83, 0x58, 0x10, 0x59, 0x25, 0x53,
@@ -892,14 +1124,17 @@ var fileDescriptorCistern = []byte{
 	0xa4, 0xd4, 0xf4, 0xcc, 0x3c, 0xe7, 0xfc, 0xdc, 0xdc, 0xcc, 0x92, 0x90, 0x60, 0x09, 0x46, 0x05,
 	0x46, 0x0d, 0xe6, 0x20, 0x54, 0x41, 0xa5, 0x38, 0x2e, 0x3e, 0x64, 0x6d, 0xc5, 0x05, 0x42, 0x52,
 	0x5c, 0x1c, 0xc9, 0xa8, 0x5a, 0xe0, 0x7c, 0x21, 0x09, 0x2e, 0xf6, 0x82, 0xc4, 0xca, 0x9c, 0xfc,
-	0xc4, 0x14, 0x09, 0x26, 0xa0, 0x14, 0x4f, 0x10, 0x8c, 0x2b, 0x24, 0xc6, 0xc5, 0x96, 0x92, 0x92,
-	0x93, 0x95, 0x9f, 0x24, 0xc1, 0x0c, 0x96, 0x80, 0xf2, 0x94, 0xcc, 0x20, 0xe6, 0xbb, 0xb8, 0xf8,
-	0x78, 0xe5, 0x27, 0x15, 0x13, 0xef, 0x2e, 0x6d, 0x2e, 0x7e, 0x14, 0x7d, 0x40, 0x87, 0x01, 0x2d,
-	0x87, 0x18, 0x5a, 0x0c, 0xd4, 0xc2, 0x0c, 0xb2, 0x1c, 0xca, 0x35, 0xea, 0x61, 0xe4, 0x62, 0x77,
-	0x86, 0x84, 0x95, 0x90, 0x3d, 0x17, 0x17, 0xc2, 0x43, 0x42, 0xa2, 0x7a, 0x90, 0x40, 0xd3, 0x43,
-	0x09, 0x1b, 0x29, 0x31, 0x6c, 0xc2, 0xc5, 0x05, 0x4a, 0x0c, 0x06, 0x8c, 0x42, 0x0e, 0x5c, 0xdc,
-	0x48, 0x36, 0x0b, 0xa1, 0x28, 0x45, 0x78, 0x43, 0x4a, 0x1c, 0xab, 0x38, 0xc8, 0x0c, 0x27, 0x81,
-	0x13, 0x8f, 0xe4, 0x18, 0x2f, 0x00, 0xf1, 0x03, 0x20, 0x9e, 0xf1, 0x58, 0x8e, 0x21, 0x89, 0x0d,
-	0x1c, 0x47, 0xc6, 0x80, 0x00, 0x00, 0x00, 0xff, 0xff, 0xb2, 0x5a, 0x2b, 0x49, 0xd2, 0x01, 0x00,
-	0x00,
+	0xc4, 0x14, 0x09, 0x26, 0x05, 0x46, 0x0d, 0x9e, 0x20, 0x18, 0x57, 0x48, 0x8c, 0x8b, 0x2d, 0x25,
+	0x25, 0x27, 0x2b, 0x3f, 0x49, 0x82, 0x19, 0x2c, 0x01, 0xe5, 0x29, 0x99, 0x41, 0xcc, 0x77, 0x71,
+	0xf1, 0xf1, 0xca, 0x4f, 0x2a, 0x26, 0xde, 0x5d, 0xda, 0x5c, 0xfc, 0x28, 0xfa, 0x8a, 0x0b, 0x40,
+	0x96, 0x43, 0x0c, 0x2d, 0x96, 0x60, 0x54, 0x60, 0x06, 0x59, 0x0e, 0xe5, 0x2a, 0x89, 0x71, 0x89,
+	0xb8, 0xa7, 0x96, 0xf8, 0x24, 0x96, 0xa4, 0x16, 0x97, 0xc0, 0x4c, 0x08, 0x4a, 0x2d, 0x54, 0x32,
+	0xe6, 0x12, 0xc5, 0x22, 0x8e, 0xdf, 0x8f, 0x46, 0x0f, 0x18, 0xb9, 0xd8, 0x9d, 0x21, 0x01, 0x2f,
+	0x64, 0xcf, 0xc5, 0x85, 0x08, 0x1d, 0x21, 0x51, 0x3d, 0x48, 0x0c, 0xe8, 0xa1, 0x04, 0xb4, 0x94,
+	0x18, 0x36, 0xe1, 0xe2, 0x02, 0x25, 0x06, 0x03, 0x46, 0x21, 0x07, 0x2e, 0x6e, 0x24, 0x6f, 0x08,
+	0xa1, 0x28, 0x45, 0x84, 0x89, 0x94, 0x38, 0x56, 0x71, 0x90, 0x19, 0x42, 0x41, 0x5c, 0x82, 0x18,
+	0x7e, 0x10, 0x92, 0x81, 0xa9, 0xc7, 0xe6, 0x6d, 0x29, 0x59, 0x3c, 0xb2, 0x20, 0x33, 0x9d, 0x04,
+	0x4e, 0x3c, 0x92, 0x63, 0xbc, 0xf0, 0x48, 0x8e, 0xf1, 0xc1, 0x23, 0x39, 0xc6, 0x19, 0x8f, 0xe5,
+	0x18, 0x92, 0xd8, 0xc0, 0x89, 0xc8, 0x18, 0x10, 0x00, 0x00, 0xff, 0xff, 0xd7, 0x73, 0xf8, 0x6d,
+	0x73, 0x02, 0x00, 0x00,
 }

--- a/proto/binlog/cistern.proto
+++ b/proto/binlog/cistern.proto
@@ -16,8 +16,8 @@ service Cistern {
     // DumpDDLJobs dumps all history DDL jobs before a specified commitTS
     rpc DumpDDLJobs(DumpDDLJobsReq) returns (DumpDDLJobsResp) {}
 
-    // GetLastCommitTS returns the Last binlog commitTS of the TiDB
-    rpc GetLastCommitTS(GetLastCommitTSReq) returns (GetLastCommitTSResp) {}
+    // GetLatestCommitTS returns the Last binlog commitTS of the TiDB
+    rpc GetLatestCommitTS(GetLatestCommitTSReq) returns (GetLatestCommitTSResp) {}
 }
 
 message DumpBinlogReq {
@@ -50,10 +50,10 @@ message DumpDDLJobsResp {
     repeated bytes ddljobs = 1;
 }
 
-message GetLastCommitTSReq {
+message GetLatestCommitTSReq {
 }
 
-message GetLastCommitTSResp {
+message GetLatestCommitTSResp {
     // CommitTS specifies the Last binlog commitTS of the TiDB
     int64 commitTS = 1;
 }

--- a/proto/binlog/cistern.proto
+++ b/proto/binlog/cistern.proto
@@ -15,6 +15,9 @@ service Cistern {
 
     // DumpDDLJobs dumps all history DDL jobs before a specified commitTS
     rpc DumpDDLJobs(DumpDDLJobsReq) returns (DumpDDLJobsResp) {}
+
+    // GetLastCommitTS returns the Last binlog commitTS of the TiDB
+    rpc GetLastCommitTS(GetLastCommitTSReq) returns (GetLastCommitTSResp) {}
 }
 
 message DumpBinlogReq {
@@ -45,4 +48,12 @@ message DumpDDLJobsReq {
 message DumpDDLJobsResp {
     // ddljobs is an array of JSON encoded history DDL jobs
     repeated bytes ddljobs = 1;
+}
+
+message GetLastCommitTSReq {
+}
+
+message GetLastCommitTSResp {
+    // CommitTS specifies the Last binlog commitTS of the TiDB
+    int64 commitTS = 1;
 }


### PR DESCRIPTION
In some scenarios like depoly binlog and switch master/slave, we need to know
the max txn commit ts over all tidbs at the switch point/dump point.
The interface can return the commit TS after cistern can't pull binlog from all
pumps.
