### PR TITLE
*: add a helper function to check existence and version of gogo's protobuf

### DIFF
--- a/_help.sh
+++ b/_help.sh
@@ -1,0 +1,23 @@
+GOGO_ROOT=${GOPATH}/src/github.com/gogo/protobuf
+
+function check_gogo_exist_and_version(){
+	if [ ! -d $GOGO_ROOT ]; then
+		echo "please use the following command to get specific version of gogo.\n\n"
+		echo "go get -u github.com/gogo/protobuf/protoc-gen-gofast"
+		echo "cd ${GOPATH}/src/github.com/gogo/protobuf"
+		echo "git checkout v0.5"
+		echo "rm ${GOPATH}/bin/protoc-gen-gofast"
+		echo "go get github.com/gogo/protobuf/protoc-gen-gofast"
+		exit 1
+	else  
+		cur_dir=$PWD
+		cd ${GOPATH}/src/github.com/gogo/protobuf
+		if [ $(git describe --tags) != 'v0.5' ]; then
+			echo "please use v0.5 tag of protobuf"
+			cd $cur_dir
+			exit 1
+		fi
+
+		cd $cur_dir
+	fi
+}

--- a/_help.sh
+++ b/_help.sh
@@ -14,6 +14,8 @@ function check_gogo_exist_and_version(){
 		cd ${GOPATH}/src/github.com/gogo/protobuf
 		if [ $(git describe --tags) != 'v0.5' ]; then
 			echo "please use v0.5 tag of protobuf"
+			echo "cd ${GOPATH}/src/github.com/gogo/protobuf"
+			echo "git checkout v0.5"
 			cd $cur_dir
 			exit 1
 		fi

--- a/generate-binlog.sh
+++ b/generate-binlog.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+source _help.sh
+
+check_gogo_exist_and_version
 cd proto/binlog
 
 echo "generate binlog code..."

--- a/generate-go.sh
+++ b/generate-go.sh
@@ -1,20 +1,14 @@
-cd proto
+source _help.sh
 
+# check gogo protobuf's existence and version
+check_gogo_exist_and_version
+
+cd proto
 echo "generate go code..."
-GOGO_ROOT=${GOPATH}/src/github.com/gogo/protobuf
-if [ ! -d $GOGO_ROOT ]; then
-	echo "please use the following command to get specific version of gogo.\n\n"
-	echo "go get -u github.com/gogo/protobuf/protoc-gen-gofast"
-	echo "cd ${GOPATH}/src/github.com/gogo/protobuf"
-	echo "git checkout v0.5"
-	echo "rm ${GOPATH}/bin/protoc-gen-gofast"
-	echo "go get github.com/gogo/protobuf/protoc-gen-gofast"
-else
-	protoc -I.:${GOGO_ROOT}:${GOGO_ROOT}/protobuf --gofast_out=../go-tipb *.proto
-	cd ../go-tipb
-	sed -i.bak -E 's/import _ \"gogoproto\"//g' *.pb.go
-	sed -i.bak -E 's/import fmt \"fmt\"//g' *.pb.go
-	rm -f *.bak
-	goimports -w *.pb.go
-fi
+protoc -I.:${GOGO_ROOT}:${GOGO_ROOT}/protobuf --gofast_out=../go-tipb *.proto
+cd ../go-tipb
+sed -i.bak -E 's/import _ \"gogoproto\"//g' *.pb.go
+sed -i.bak -E 's/import fmt \"fmt\"//g' *.pb.go
+rm -f *.bak
+goimports -w *.pb.go
 

--- a/generate-mysqlx.sh
+++ b/generate-mysqlx.sh
@@ -1,3 +1,6 @@
+source _help.sh
+
+check_gogo_exist_and_version
 cd proto
 
 echo "generate go code..."


### PR DESCRIPTION
While I was trying to generate new proto code, I made a mistake. I use the latest gogo's protobuf rather than v0.5. I felt like we need make this rule into code. That is why I create this PR. I wish I could be the last person to make the same mistake. 