### PR TITLE
fix make fail

### DIFF
--- a/generate-binlog.sh
+++ b/generate-binlog.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-source _help.sh
+source ./_help.sh
 
 check_gogo_exist_and_version
 cd proto/binlog

--- a/generate-go.sh
+++ b/generate-go.sh
@@ -1,4 +1,4 @@
-source _help.sh
+source ./_help.sh
 
 # check gogo protobuf's existence and version
 check_gogo_exist_and_version


### PR DESCRIPTION
make on unbuntu. PATH does not contains '.' usually.
```
./generate-go.sh
./generate-go.sh: 第 1 行: source: _help.sh: 文件未找到
Makefile:4: recipe for target 'go' failed
make: *** [go] Error 1
```
