### PR TITLE
Use Git dep for Prost

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ name = "tipb"
 
 [dependencies]
 protobuf = "2"
-prost = { version = "0.5", optional = true }
-prost-derive = { version = "0.5", optional = true }
+prost = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77", optional = true }
+prost-derive = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77", optional = true }
 bytes = { version = "0.4", optional = true }
 lazy_static = { version = "1.3", optional = true }
 


### PR DESCRIPTION
Use a Git dep for Prost so we get some optimisations which are not present in the current release.

PTAL @overvenus @Hoverbear 