### PR TITLE
Not build generated cpp file in gen cpp script

### DIFF
--- a/generate-cpp.sh
+++ b/generate-cpp.sh
@@ -3,7 +3,7 @@
 rm -rf proto-cpp && mkdir -p proto-cpp
 rm -rf cpp/tipb && mkdir cpp/tipb
 
-cp proto/* proto-cpp/
+cp proto/*.proto proto-cpp/
 
 function sed_inplace()
 {
@@ -23,4 +23,4 @@ echo "generate cpp code..."
 protoc --cpp_out=../cpp/tipb/ *.proto
 cd ..
 
-rm -rf proto-cpp && rm -rf build_cpp && mkdir build_cpp && cd build_cpp && cmake ../cpp && make && cd .. && rm -rf build_cpp
+rm -rf proto-cpp


### PR DESCRIPTION
We do not need to build the generated cpp files in our gen script, as building those cpp files requires subtle settings of cpp dev environment, i.e. compiler, include dir, linker options, etc. which are normally done in the Makefile or cmake file of the project that includes tipb as a dependency.