### PR TITLE
Update protobuf-build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ bytes = { version = "0.4", optional = true }
 lazy_static = { version = "1.3", optional = true }
 
 [build-dependencies]
-protobuf-build = { version = "0.9.1", default-features = false }
+protobuf-build = { version = "0.10", default-features = false }


### PR DESCRIPTION
Changes the type of wrapper functions for repeated fields from `&Vec<_>` to `&[_]`

PTAL @Hoverbear @hicqu 