### PR TITLE
add checksum rewrite rule

### DIFF
--- a/go-tipb/analyze.pb.go
+++ b/go-tipb/analyze.pb.go
@@ -25,6 +25,7 @@
 		CMSketchRow
 		CMSketchTopN
 		CMSketch
+		ChecksumRewriteRule
 		ChecksumRequest
 		ChecksumResponse
 		Executor

--- a/go-tipb/checksum.pb.go
+++ b/go-tipb/checksum.pb.go
@@ -83,17 +83,43 @@ func (x *ChecksumAlgorithm) UnmarshalJSON(data []byte) error {
 }
 func (ChecksumAlgorithm) EnumDescriptor() ([]byte, []int) { return fileDescriptorChecksum, []int{1} }
 
+type ChecksumRewriteRule struct {
+	OldPrefix        []byte `protobuf:"bytes,1,opt,name=old_prefix,json=oldPrefix" json:"old_prefix,omitempty"`
+	NewPrefix        []byte `protobuf:"bytes,2,opt,name=new_prefix,json=newPrefix" json:"new_prefix,omitempty"`
+	XXX_unrecognized []byte `json:"-"`
+}
+
+func (m *ChecksumRewriteRule) Reset()                    { *m = ChecksumRewriteRule{} }
+func (m *ChecksumRewriteRule) String() string            { return proto.CompactTextString(m) }
+func (*ChecksumRewriteRule) ProtoMessage()               {}
+func (*ChecksumRewriteRule) Descriptor() ([]byte, []int) { return fileDescriptorChecksum, []int{0} }
+
+func (m *ChecksumRewriteRule) GetOldPrefix() []byte {
+	if m != nil {
+		return m.OldPrefix
+	}
+	return nil
+}
+
+func (m *ChecksumRewriteRule) GetNewPrefix() []byte {
+	if m != nil {
+		return m.NewPrefix
+	}
+	return nil
+}
+
 type ChecksumRequest struct {
-	StartTs          uint64            `protobuf:"varint,1,opt,name=start_ts,json=startTs" json:"start_ts"`
-	ScanOn           ChecksumScanOn    `protobuf:"varint,2,opt,name=scan_on,json=scanOn,enum=tipb.ChecksumScanOn" json:"scan_on"`
-	Algorithm        ChecksumAlgorithm `protobuf:"varint,3,opt,name=algorithm,enum=tipb.ChecksumAlgorithm" json:"algorithm"`
-	XXX_unrecognized []byte            `json:"-"`
+	StartTs          uint64               `protobuf:"varint,1,opt,name=start_ts,json=startTs" json:"start_ts"`
+	ScanOn           ChecksumScanOn       `protobuf:"varint,2,opt,name=scan_on,json=scanOn,enum=tipb.ChecksumScanOn" json:"scan_on"`
+	Algorithm        ChecksumAlgorithm    `protobuf:"varint,3,opt,name=algorithm,enum=tipb.ChecksumAlgorithm" json:"algorithm"`
+	Rule             *ChecksumRewriteRule `protobuf:"bytes,4,opt,name=rule" json:"rule,omitempty"`
+	XXX_unrecognized []byte               `json:"-"`
 }
 
 func (m *ChecksumRequest) Reset()                    { *m = ChecksumRequest{} }
 func (m *ChecksumRequest) String() string            { return proto.CompactTextString(m) }
 func (*ChecksumRequest) ProtoMessage()               {}
-func (*ChecksumRequest) Descriptor() ([]byte, []int) { return fileDescriptorChecksum, []int{0} }
+func (*ChecksumRequest) Descriptor() ([]byte, []int) { return fileDescriptorChecksum, []int{1} }
 
 func (m *ChecksumRequest) GetStartTs() uint64 {
 	if m != nil {
@@ -116,6 +142,13 @@ func (m *ChecksumRequest) GetAlgorithm() ChecksumAlgorithm {
 	return ChecksumAlgorithm_Crc64_Xor
 }
 
+func (m *ChecksumRequest) GetRule() *ChecksumRewriteRule {
+	if m != nil {
+		return m.Rule
+	}
+	return nil
+}
+
 type ChecksumResponse struct {
 	Checksum         uint64 `protobuf:"varint,1,opt,name=checksum" json:"checksum"`
 	TotalKvs         uint64 `protobuf:"varint,2,opt,name=total_kvs,json=totalKvs" json:"total_kvs"`
@@ -126,7 +159,7 @@ type ChecksumResponse struct {
 func (m *ChecksumResponse) Reset()                    { *m = ChecksumResponse{} }
 func (m *ChecksumResponse) String() string            { return proto.CompactTextString(m) }
 func (*ChecksumResponse) ProtoMessage()               {}
-func (*ChecksumResponse) Descriptor() ([]byte, []int) { return fileDescriptorChecksum, []int{1} }
+func (*ChecksumResponse) Descriptor() ([]byte, []int) { return fileDescriptorChecksum, []int{2} }
 
 func (m *ChecksumResponse) GetChecksum() uint64 {
 	if m != nil {
@@ -150,11 +183,45 @@ func (m *ChecksumResponse) GetTotalBytes() uint64 {
 }
 
 func init() {
+	proto.RegisterType((*ChecksumRewriteRule)(nil), "tipb.ChecksumRewriteRule")
 	proto.RegisterType((*ChecksumRequest)(nil), "tipb.ChecksumRequest")
 	proto.RegisterType((*ChecksumResponse)(nil), "tipb.ChecksumResponse")
 	proto.RegisterEnum("tipb.ChecksumScanOn", ChecksumScanOn_name, ChecksumScanOn_value)
 	proto.RegisterEnum("tipb.ChecksumAlgorithm", ChecksumAlgorithm_name, ChecksumAlgorithm_value)
 }
+func (m *ChecksumRewriteRule) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ChecksumRewriteRule) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.OldPrefix != nil {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintChecksum(dAtA, i, uint64(len(m.OldPrefix)))
+		i += copy(dAtA[i:], m.OldPrefix)
+	}
+	if m.NewPrefix != nil {
+		dAtA[i] = 0x12
+		i++
+		i = encodeVarintChecksum(dAtA, i, uint64(len(m.NewPrefix)))
+		i += copy(dAtA[i:], m.NewPrefix)
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
 func (m *ChecksumRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -179,6 +246,16 @@ func (m *ChecksumRequest) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x18
 	i++
 	i = encodeVarintChecksum(dAtA, i, uint64(m.Algorithm))
+	if m.Rule != nil {
+		dAtA[i] = 0x22
+		i++
+		i = encodeVarintChecksum(dAtA, i, uint64(m.Rule.Size()))
+		n1, err := m.Rule.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n1
+	}
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -224,12 +301,33 @@ func encodeVarintChecksum(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return offset + 1
 }
+func (m *ChecksumRewriteRule) Size() (n int) {
+	var l int
+	_ = l
+	if m.OldPrefix != nil {
+		l = len(m.OldPrefix)
+		n += 1 + l + sovChecksum(uint64(l))
+	}
+	if m.NewPrefix != nil {
+		l = len(m.NewPrefix)
+		n += 1 + l + sovChecksum(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
 func (m *ChecksumRequest) Size() (n int) {
 	var l int
 	_ = l
 	n += 1 + sovChecksum(uint64(m.StartTs))
 	n += 1 + sovChecksum(uint64(m.ScanOn))
 	n += 1 + sovChecksum(uint64(m.Algorithm))
+	if m.Rule != nil {
+		l = m.Rule.Size()
+		n += 1 + l + sovChecksum(uint64(l))
+	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -260,6 +358,119 @@ func sovChecksum(x uint64) (n int) {
 }
 func sozChecksum(x uint64) (n int) {
 	return sovChecksum(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *ChecksumRewriteRule) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowChecksum
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ChecksumRewriteRule: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ChecksumRewriteRule: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field OldPrefix", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowChecksum
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthChecksum
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.OldPrefix = append(m.OldPrefix[:0], dAtA[iNdEx:postIndex]...)
+			if m.OldPrefix == nil {
+				m.OldPrefix = []byte{}
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NewPrefix", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowChecksum
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthChecksum
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.NewPrefix = append(m.NewPrefix[:0], dAtA[iNdEx:postIndex]...)
+			if m.NewPrefix == nil {
+				m.NewPrefix = []byte{}
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipChecksum(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthChecksum
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
 }
 func (m *ChecksumRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
@@ -347,6 +558,39 @@ func (m *ChecksumRequest) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Rule", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowChecksum
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthChecksum
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Rule == nil {
+				m.Rule = &ChecksumRewriteRule{}
+			}
+			if err := m.Rule.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipChecksum(dAtA[iNdEx:])
@@ -585,26 +829,29 @@ var (
 func init() { proto.RegisterFile("checksum.proto", fileDescriptorChecksum) }
 
 var fileDescriptorChecksum = []byte{
-	// 321 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x64, 0x90, 0x41, 0x4e, 0xc2, 0x40,
-	0x14, 0x86, 0x3b, 0x8a, 0x42, 0x9f, 0x11, 0xeb, 0x04, 0x23, 0x71, 0x51, 0x90, 0x44, 0x83, 0x2c,
-	0x6a, 0xa2, 0xc6, 0x8d, 0x2b, 0x61, 0x65, 0x5c, 0x68, 0x90, 0x85, 0xbb, 0x66, 0x3a, 0x4c, 0x4a,
-	0x03, 0xcc, 0xd4, 0xbe, 0x81, 0xe8, 0xc6, 0x73, 0x78, 0x00, 0x0f, 0xc3, 0xd2, 0x13, 0x18, 0x83,
-	0x17, 0x31, 0x1d, 0x28, 0xa4, 0x71, 0xf7, 0xe6, 0x7f, 0xdf, 0x3f, 0xf3, 0xff, 0x03, 0x65, 0x3e,
-	0x10, 0x7c, 0x88, 0x93, 0xb1, 0x17, 0x27, 0x4a, 0x2b, 0x5a, 0xd0, 0x51, 0x1c, 0x1c, 0x55, 0x42,
-	0x15, 0x2a, 0x23, 0x9c, 0xa7, 0xd3, 0x62, 0xd7, 0xf8, 0x24, 0xb0, 0xd7, 0x59, 0xe2, 0x5d, 0xf1,
-	0x32, 0x11, 0xa8, 0x69, 0x0d, 0x4a, 0xa8, 0x59, 0xa2, 0x7d, 0x8d, 0x55, 0x52, 0x27, 0xcd, 0x42,
-	0xbb, 0x30, 0xfb, 0xae, 0x59, 0xdd, 0xa2, 0x51, 0x7b, 0x48, 0x2f, 0xa1, 0x88, 0x9c, 0x49, 0x5f,
-	0xc9, 0xea, 0x46, 0x9d, 0x34, 0xcb, 0x17, 0x15, 0x2f, 0x7d, 0xc2, 0xcb, 0x2e, 0x7a, 0xe2, 0x4c,
-	0x3e, 0xc8, 0xa5, 0x6b, 0x1b, 0xcd, 0x89, 0xde, 0x80, 0xcd, 0x46, 0xa1, 0x4a, 0x22, 0x3d, 0x18,
-	0x57, 0x37, 0x8d, 0xed, 0x30, 0x6f, 0xbb, 0xcd, 0xd6, 0x4b, 0xe7, 0x9a, 0x6f, 0xbc, 0x83, 0xb3,
-	0x4e, 0x89, 0xb1, 0x92, 0x28, 0x68, 0x1d, 0x4a, 0x59, 0xd1, 0x5c, 0xcc, 0x95, 0x4a, 0x8f, 0xc1,
-	0xd6, 0x4a, 0xb3, 0x91, 0x3f, 0x9c, 0xa2, 0x49, 0xba, 0x42, 0x8c, 0x7c, 0x3f, 0x45, 0x7a, 0x02,
-	0x3b, 0x0b, 0x24, 0x78, 0xd3, 0x02, 0x4d, 0xae, 0x0c, 0x02, 0xb3, 0x68, 0xa7, 0x7a, 0xeb, 0x14,
-	0xca, 0xf9, 0x72, 0xd4, 0x86, 0xad, 0x1e, 0x0b, 0x46, 0xc2, 0xb1, 0xd2, 0xf1, 0x4e, 0xf6, 0xc5,
-	0xab, 0x43, 0x5a, 0x0d, 0xd8, 0xff, 0xd7, 0x86, 0xee, 0x82, 0xdd, 0x49, 0xf8, 0xf5, 0x95, 0xff,
-	0xac, 0x12, 0xc7, 0x6a, 0x9f, 0xcd, 0xe6, 0x2e, 0xf9, 0x9a, 0xbb, 0xe4, 0x67, 0xee, 0x92, 0x8f,
-	0x5f, 0xd7, 0x82, 0x03, 0xae, 0xc6, 0x5e, 0x1c, 0xc9, 0x90, 0xb3, 0xd8, 0xd3, 0x51, 0x3f, 0x30,
-	0xff, 0xf2, 0x48, 0xfe, 0x02, 0x00, 0x00, 0xff, 0xff, 0x40, 0x2d, 0x34, 0x0d, 0xca, 0x01, 0x00,
-	0x00,
+	// 384 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x64, 0x90, 0xcf, 0x8f, 0xd2, 0x40,
+	0x1c, 0xc5, 0x3b, 0x5a, 0x85, 0x7e, 0x51, 0xac, 0x23, 0x46, 0x34, 0xb1, 0x60, 0x13, 0x0d, 0x92,
+	0x58, 0x13, 0x34, 0x5e, 0x3c, 0x09, 0x27, 0xe3, 0x41, 0x52, 0x38, 0x78, 0x6b, 0xfa, 0x63, 0x2c,
+	0x0d, 0x65, 0xa6, 0xce, 0x4c, 0x01, 0x2f, 0xfb, 0x77, 0xec, 0x9f, 0xc4, 0x71, 0x93, 0xbd, 0x6f,
+	0x36, 0xec, 0x3f, 0xb2, 0xe9, 0x94, 0xc2, 0x36, 0x7b, 0x9b, 0xbe, 0xcf, 0x7b, 0xdf, 0xf4, 0x3d,
+	0x68, 0x87, 0x0b, 0x12, 0x2e, 0x45, 0xbe, 0x72, 0x32, 0xce, 0x24, 0xc3, 0xba, 0x4c, 0xb2, 0xe0,
+	0x4d, 0x27, 0x66, 0x31, 0x53, 0xc2, 0xe7, 0xe2, 0x55, 0x32, 0x7b, 0x06, 0x2f, 0x26, 0x07, 0xb7,
+	0x4b, 0x36, 0x3c, 0x91, 0xc4, 0xcd, 0x53, 0x82, 0xdf, 0x02, 0xb0, 0x34, 0xf2, 0x32, 0x4e, 0xfe,
+	0x26, 0xdb, 0x2e, 0xea, 0xa3, 0xc1, 0x13, 0xd7, 0x60, 0x69, 0x34, 0x55, 0x42, 0x81, 0x29, 0xd9,
+	0x54, 0xf8, 0x41, 0x89, 0x29, 0xd9, 0x94, 0xd8, 0xbe, 0x44, 0xf0, 0xec, 0x74, 0xf5, 0x5f, 0x4e,
+	0x84, 0xc4, 0x3d, 0x68, 0x0a, 0xe9, 0x73, 0xe9, 0x49, 0xa1, 0xee, 0xe9, 0x63, 0x7d, 0x77, 0xd5,
+	0xd3, 0xdc, 0x86, 0x52, 0xe7, 0x02, 0x7f, 0x81, 0x86, 0x08, 0x7d, 0xea, 0x31, 0xaa, 0x0e, 0xb6,
+	0x47, 0x1d, 0xa7, 0xf8, 0x6f, 0xa7, 0x3a, 0x34, 0x0b, 0x7d, 0xfa, 0x9b, 0x1e, 0x52, 0x8f, 0x85,
+	0xfa, 0xc2, 0xdf, 0xc1, 0xf0, 0xd3, 0x98, 0xf1, 0x44, 0x2e, 0x56, 0xdd, 0x87, 0x2a, 0xf6, 0xaa,
+	0x1e, 0xfb, 0x51, 0xe1, 0x43, 0xf2, 0xe4, 0xc7, 0x9f, 0x40, 0xe7, 0x79, 0x4a, 0xba, 0x7a, 0x1f,
+	0x0d, 0x5a, 0xa3, 0xd7, 0xf5, 0xdc, 0x9d, 0x35, 0x5c, 0x65, 0xb3, 0xcf, 0xc0, 0x3c, 0x41, 0x91,
+	0x31, 0x2a, 0x08, 0xee, 0x43, 0xb3, 0x1a, 0xbb, 0xd6, 0xea, 0xa8, 0xe2, 0x77, 0x60, 0x48, 0x26,
+	0xfd, 0xd4, 0x5b, 0xae, 0x85, 0x2a, 0x76, 0xb4, 0x28, 0xf9, 0xd7, 0x5a, 0xe0, 0xf7, 0xd0, 0x2a,
+	0x2d, 0xc1, 0x7f, 0x49, 0x84, 0xaa, 0x51, 0x99, 0x40, 0x81, 0x71, 0xa1, 0x0f, 0x3f, 0x40, 0xbb,
+	0xbe, 0x05, 0x36, 0xe0, 0xd1, 0xdc, 0x0f, 0x52, 0x62, 0x6a, 0xc5, 0xf3, 0x27, 0x8d, 0xc8, 0xd6,
+	0x44, 0x43, 0x1b, 0x9e, 0xdf, 0x2b, 0x8f, 0x9f, 0x82, 0x31, 0xe1, 0xe1, 0xb7, 0xaf, 0xde, 0x1f,
+	0xc6, 0x4d, 0x6d, 0xfc, 0x71, 0xb7, 0xb7, 0xd0, 0xc5, 0xde, 0x42, 0xd7, 0x7b, 0x0b, 0x9d, 0xdf,
+	0x58, 0x1a, 0xbc, 0x0c, 0xd9, 0xca, 0xc9, 0x12, 0x1a, 0x87, 0x7e, 0xe6, 0xc8, 0x24, 0x0a, 0xd4,
+	0x1c, 0x53, 0x74, 0x1b, 0x00, 0x00, 0xff, 0xff, 0x08, 0x3e, 0xe9, 0xa1, 0x4e, 0x02, 0x00, 0x00,
 }

--- a/proto/checksum.proto
+++ b/proto/checksum.proto
@@ -20,10 +20,16 @@ enum ChecksumAlgorithm {
     Crc64_Xor = 0;
 }
 
+message ChecksumRewriteRule {
+    optional bytes old_prefix = 1;
+    optional bytes new_prefix = 2;
+}
+
 message ChecksumRequest {
     optional uint64 start_ts = 1 [(gogoproto.nullable) = false];
     optional ChecksumScanOn scan_on = 2 [(gogoproto.nullable) = false];
     optional ChecksumAlgorithm algorithm = 3 [(gogoproto.nullable) = false];
+    optional ChecksumRewriteRule rule = 4;
 }
 
 message ChecksumResponse {


### PR DESCRIPTION
when restore data in new node with new table_id, we need rewrite prefix with old table_id in calculating checksum request