### PR TITLE
Better integration with cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 .DS_Store
 cpp/tipb/*.h
 cpp/tipb/*.cc
+cpp/build/

--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,6 @@ binlog: dependence
 
 c++: dependence
 	./generate-cpp.sh
+
+tipb.a:
+	mkdir -p cpp/build && cd cpp/build && cmake -DCMAKE_BUILD_TYPE=Release .. && make tipb

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 2.8.12)
+
+project(tipb)
 
 set (CMAKE_CXX_STANDARD 17)
 
@@ -13,8 +15,72 @@ else ()
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 endif ()
 
-file(GLOB __tmp RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} tipb/*.cc tipb/*.h)
-list(APPEND generated_files ${__tmp})
+find_package(Protobuf REQUIRED)
+message(STATUS "Using protobuf: ${Protobuf_VERSION} : ${Protobuf_INCLUDE_DIRS}, ${Protobuf_LIBRARIES}")
 
-add_library(tipb ${generated_files})
-target_include_directories(tipb PUBLIC ./)
+find_package(gRPC CONFIG REQUIRED)
+message(STATUS "Using gRPC: ${gRPC_VERSION}")
+
+# .proto files
+set (PROTO_DEF_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../proto")
+file (GLOB PROTO_DEFS "${PROTO_DEF_DIR}/*.proto")
+# The output dir for .pb.h, .pb.cc
+set (PROTO_OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/tipb")
+file (MAKE_DIRECTORY "${PROTO_OUTPUT_DIR}")
+# A temporary directory for proto file without gogoproto marks
+set (PROTO_DEF_TMP_DIR "${CMAKE_CURRENT_BINARY_DIR}/protos")
+file (MAKE_DIRECTORY "${PROTO_DEF_TMP_DIR}")
+
+set (CLEAN_PROTO_DEFS "")
+foreach (F ${PROTO_DEFS})
+    get_filename_component (ABS_FIL ${F} ABSOLUTE)
+    get_filename_component (FIL_WE ${F} NAME_WE)
+    list (APPEND CLEAN_PROTO_DEFS "${PROTO_DEF_TMP_DIR}/${FIL_WE}.proto")
+    # Generate a output file by copying and cleaning up gogoproto marks.
+    # Will be re-generated if the original .proto file is changed.
+    add_custom_command(
+        OUTPUT "${PROTO_DEF_TMP_DIR}/${FIL_WE}.proto"
+        WORKING_DIRECTORY ${PROTO_DEF_DIR}
+        COMMAND cp ${ABS_FIL} ${PROTO_DEF_TMP_DIR}/${FIL_WE}.proto
+        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/../generate-cpp.sh"
+        ARGS clean ${PROTO_DEF_TMP_DIR}/${FIL_WE}.proto
+        DEPENDS ${ABS_FIL}
+        COMMENT "Generating clean proto file on ${ABS_FIL}"
+        VERBATIM)
+endforeach()
+# Grab all clean .proto files as a target
+add_custom_target (__clean_proto_defs
+    DEPENDS ${CLEAN_PROTO_DEFS}
+    VERBATIM)
+
+set (PROTO_SRCS "")
+set (PROTO_HDRS "")
+foreach (F ${PROTO_DEFS})
+    get_filename_component (ABS_FIL ${F} ABSOLUTE)
+    get_filename_component (FIL_WE ${F} NAME_WE)
+
+    list (APPEND PROTO_SRCS "${PROTO_OUTPUT_DIR}/${FIL_WE}.pb.cc")
+    list (APPEND PROTO_HDRS "${PROTO_OUTPUT_DIR}/${FIL_WE}.pb.h")
+    # Create the generated cpp files for .proto file.
+    # Add dependency on the original .proto file and `__clean_proto_defs`
+    # so that it can re-generate source files if .proto changed.
+    add_custom_command(
+        OUTPUT "${PROTO_OUTPUT_DIR}/${FIL_WE}.pb.cc"
+               "${PROTO_OUTPUT_DIR}/${FIL_WE}.pb.h"
+        WORKING_DIRECTORY ${PROTO_DEF_TMP_DIR}
+        COMMAND protobuf::protoc
+        ARGS --cpp_out=${PROTO_OUTPUT_DIR} ${PROTO_DEF_TMP_DIR}/${FIL_WE}.proto -I ${PROTO_DEF_TMP_DIR}
+        DEPENDS ${ABS_FIL} protobuf::protoc __clean_proto_defs
+        COMMENT "Running C++ protocol buffer compiler on ${ABS_FIL}"
+        VERBATIM)
+endforeach()
+
+# Mark those clean .proto, .pb.h, .pb.cc files are generated
+# so that they can be re-build if changed and clean by `make clean`
+set_source_files_properties(${CLEAN_PROTO_DEFS} ${PROTO_SRCS} ${PROTO_HDRS} PROPERTIES GENERATED TRUE)
+
+add_library(tipb ${PROTO_SRCS} ${PROTO_HDRS})
+target_include_directories(tipb PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${PROTOBUF_INCLUDE_DIRS}
+)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -49,7 +49,7 @@ foreach (F ${PROTO_DEFS})
         VERBATIM)
 endforeach()
 # Grab all clean .proto files as a target
-add_custom_target (__clean_proto_defs
+add_custom_target (__clean_tipb_defs
     DEPENDS ${CLEAN_PROTO_DEFS}
     VERBATIM)
 
@@ -62,7 +62,7 @@ foreach (F ${PROTO_DEFS})
     list (APPEND PROTO_SRCS "${PROTO_OUTPUT_DIR}/${FIL_WE}.pb.cc")
     list (APPEND PROTO_HDRS "${PROTO_OUTPUT_DIR}/${FIL_WE}.pb.h")
     # Create the generated cpp files for .proto file.
-    # Add dependency on the original .proto file and `__clean_proto_defs`
+    # Add dependency on the original .proto file and `__clean_tipb_defs`
     # so that it can re-generate source files if .proto changed.
     add_custom_command(
         OUTPUT "${PROTO_OUTPUT_DIR}/${FIL_WE}.pb.cc"
@@ -70,7 +70,7 @@ foreach (F ${PROTO_DEFS})
         WORKING_DIRECTORY ${PROTO_DEF_TMP_DIR}
         COMMAND protobuf::protoc
         ARGS --cpp_out=${PROTO_OUTPUT_DIR} ${PROTO_DEF_TMP_DIR}/${FIL_WE}.proto -I ${PROTO_DEF_TMP_DIR}
-        DEPENDS ${ABS_FIL} protobuf::protoc __clean_proto_defs
+        DEPENDS ${ABS_FIL} protobuf::protoc __clean_tipb_defs
         COMMENT "Running C++ protocol buffer compiler on ${ABS_FIL}"
         VERBATIM)
 endforeach()

--- a/generate-cpp.sh
+++ b/generate-cpp.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-rm -rf proto-cpp && mkdir -p proto-cpp
-rm -rf cpp/tipb && mkdir cpp/tipb
-
-cp proto/*.proto proto-cpp/
-
 function sed_inplace()
 {
     if sed --help 2>/dev/null | grep GNU > /dev/null; then
@@ -15,9 +10,36 @@ function sed_inplace()
     fi
 }
 
-sed_inplace '/gogo.proto/d' proto-cpp/*
-sed_inplace '/option\ (gogoproto/d' proto-cpp/*
-sed_inplace -e 's/\[.*gogoproto.*\]//g' proto-cpp/*
+# Clean up special marks for gogoproto
+function clean_up()
+{
+    local file=$1
+    sed_inplace '/gogo.proto/d' ${file}
+    sed_inplace '/option\ (gogoproto/d' ${file}
+    sed_inplace -e 's/\[.*gogoproto.*\]//g' ${file}
+}
+
+if [ "$#" -eq 2 ]; then
+    cmd="$1"
+    file="$2"
+    # <prog> clean ${file} -- clean up special marks
+    if [[ ${cmd} != "clean" || ! -f ${file} ]]; then
+        echo "Fail to clean up original file. cmd=${cmd}, file=${file}" >&2
+        exit 1
+    fi
+    clean_up ${file}
+    exit 0
+fi
+
+# Clean up special marks and re-generate .pb.h, .pb.cc files
+rm -rf proto-cpp && mkdir -p proto-cpp
+rm -rf cpp/tipb && mkdir cpp/tipb
+
+cp proto/*.proto proto-cpp/
+
+for file in `ls proto-cpp/*`; do
+    clean_up ${file}
+done
 
 cd proto-cpp
 echo "generate cpp code..."


### PR DESCRIPTION
Automatically re-generate `.pb.h` and `.pb.cc` if `.proto` file changed, don't need to run `generate-cpp.sh` manually.