### PR TITLE
build: Add docker building toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM rust
+WORKDIR /usr/src/tipb-build
+RUN apt update && apt install unzip golang cmake -y
+RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip
+RUN unzip protoc-3.5.1-linux-x86_64.zip
+ENV PATH="/usr/src/tipb-build/bin:/root/go/bin:${PATH}"
+WORKDIR /tipb
+ENTRYPOINT ["/usr/bin/make"]
+CMD ["all"]

--- a/README.md
+++ b/README.md
@@ -2,16 +2,38 @@
 
 TiDB protobuf files
 
-## Requirements
+## Build with local toolchain
 
 ### Install [google/protobuf](https://github.com/google/protobuf)
 
 We use `protoc` 3.5.1, to download: [protobuf/releases/tag/v3.5.1](https://github.com/google/protobuf/releases/tag/v3.5.1)
 
-## Generate the Go and Rust codes
+### Generate the Go and Rust codes
 
 ```sh
 make
 ```
 
-NOTE: Do not forget to update the dependent projects!
+## Build with docker
+
+### Build the docker image
+
+```sh
+docker build . -t tipb-builder
+```
+
+### Generate codes
+
+Basically just use the docker image instead of `make`:
+
+```sh
+# Generate All codes
+docker run -v $(pwd):/tipb tipb-builder 
+# Generate Go codes only
+docker run -v $(pwd):/tipb tipb-builder go
+# Generate Rust codes only
+docker run -v $(pwd):/tipb tipb-builder rust
+```
+
+## Note
+Do not forget to update the dependent projects!


### PR DESCRIPTION
Signed-off-by: longfangsong <longfangsong@icloud.com>

### What problem does this PR solve?

Problem Summary:

Building protobuf codes requires so many dependencies and environments (and some of them are not documented), it's too troublesome.

[kvproto](https://github.com/pingcap/kvproto) has already have a docker based building infrastructure, maybe we can have one here too.

### What is changed and how it works?

What's Changed:

Add a Dockerfile to create a docker image, which contains all the environment settings we need.

We can use this docker image to do the build work without pain.

How it Works:

See the new readme.md.

