### PR TITLE
revise binary plan to improve flexibility

### DIFF
--- a/go-tipb/analyze.pb.go
+++ b/go-tipb/analyze.pb.go
@@ -57,6 +57,7 @@
 		Window
 		ExplainData
 		ExplainOperator
+		AccessObject
 		DynamicPartitionAccessObjects
 		DynamicPartitionAccessObject
 		ScanAccessObject

--- a/go-tipb/explain.pb.go
+++ b/go-tipb/explain.pb.go
@@ -77,35 +77,36 @@ func (x StoreType) String() string {
 }
 func (StoreType) EnumDescriptor() ([]byte, []int) { return fileDescriptorExplain, []int{1} }
 
-type DriverSide int32
+type OperatorLabel int32
 
 const (
-	DriverSide_empty     DriverSide = 0
-	DriverSide_build     DriverSide = 1
-	DriverSide_probe     DriverSide = 2
-	DriverSide_seed      DriverSide = 3
-	DriverSide_recursive DriverSide = 4
+	// empty is not expected to be used.
+	OperatorLabel_empty         OperatorLabel = 0
+	OperatorLabel_buildSide     OperatorLabel = 1
+	OperatorLabel_probeSide     OperatorLabel = 2
+	OperatorLabel_seedPart      OperatorLabel = 3
+	OperatorLabel_recursivePart OperatorLabel = 4
 )
 
-var DriverSide_name = map[int32]string{
+var OperatorLabel_name = map[int32]string{
 	0: "empty",
-	1: "build",
-	2: "probe",
-	3: "seed",
-	4: "recursive",
+	1: "buildSide",
+	2: "probeSide",
+	3: "seedPart",
+	4: "recursivePart",
 }
-var DriverSide_value = map[string]int32{
-	"empty":     0,
-	"build":     1,
-	"probe":     2,
-	"seed":      3,
-	"recursive": 4,
+var OperatorLabel_value = map[string]int32{
+	"empty":         0,
+	"buildSide":     1,
+	"probeSide":     2,
+	"seedPart":      3,
+	"recursivePart": 4,
 }
 
-func (x DriverSide) String() string {
-	return proto.EnumName(DriverSide_name, int32(x))
+func (x OperatorLabel) String() string {
+	return proto.EnumName(OperatorLabel_name, int32(x))
 }
-func (DriverSide) EnumDescriptor() ([]byte, []int) { return fileDescriptorExplain, []int{2} }
+func (OperatorLabel) EnumDescriptor() ([]byte, []int) { return fileDescriptorExplain, []int{2} }
 
 type ExplainData struct {
 	Main *ExplainOperator   `protobuf:"bytes,1,opt,name=main" json:"main,omitempty"`
@@ -152,9 +153,9 @@ func (m *ExplainData) GetDiscardedDueToTooLong() bool {
 }
 
 type ExplainOperator struct {
-	Name       string             `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Children   []*ExplainOperator `protobuf:"bytes,2,rep,name=children" json:"children,omitempty"`
-	DriverSide DriverSide         `protobuf:"varint,3,opt,name=driver_side,json=driverSide,proto3,enum=tipb.DriverSide" json:"driver_side,omitempty"`
+	Name     string             `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Children []*ExplainOperator `protobuf:"bytes,2,rep,name=children" json:"children,omitempty"`
+	Labels   []OperatorLabel    `protobuf:"varint,3,rep,packed,name=labels,enum=tipb.OperatorLabel" json:"labels,omitempty"`
 	// the cost of the current operator
 	Cost      float64   `protobuf:"fixed64,4,opt,name=cost,proto3" json:"cost,omitempty"`
 	EstRows   float64   `protobuf:"fixed64,5,opt,name=est_rows,json=estRows,proto3" json:"est_rows,omitempty"`
@@ -162,53 +163,21 @@ type ExplainOperator struct {
 	TaskType  TaskType  `protobuf:"varint,7,opt,name=task_type,json=taskType,proto3,enum=tipb.TaskType" json:"task_type,omitempty"`
 	StoreType StoreType `protobuf:"varint,8,opt,name=store_type,json=storeType,proto3,enum=tipb.StoreType" json:"store_type,omitempty"`
 	// The XXXReader/XXXScan/MemTable/PointGet/BatchPointGet may use this
-	//
-	// Types that are valid to be assigned to AccessObject:
-	//	*ExplainOperator_ScanObject
-	//	*ExplainOperator_DynamicPartitionObjects
-	//	*ExplainOperator_OtherObject
-	AccessObject      isExplainOperator_AccessObject `protobuf_oneof:"access_object"`
-	OperatorInfo      string                         `protobuf:"bytes,12,opt,name=operator_info,json=operatorInfo,proto3" json:"operator_info,omitempty"`
-	RootBasicExecInfo string                         `protobuf:"bytes,13,opt,name=root_basic_exec_info,json=rootBasicExecInfo,proto3" json:"root_basic_exec_info,omitempty"`
-	RootGroupExecInfo []string                       `protobuf:"bytes,14,rep,name=root_group_exec_info,json=rootGroupExecInfo" json:"root_group_exec_info,omitempty"`
-	CopExecInfo       string                         `protobuf:"bytes,15,opt,name=cop_exec_info,json=copExecInfo,proto3" json:"cop_exec_info,omitempty"`
+	AccessObjects     []*AccessObject `protobuf:"bytes,9,rep,name=access_objects,json=accessObjects" json:"access_objects,omitempty"`
+	OperatorInfo      string          `protobuf:"bytes,10,opt,name=operator_info,json=operatorInfo,proto3" json:"operator_info,omitempty"`
+	RootBasicExecInfo string          `protobuf:"bytes,11,opt,name=root_basic_exec_info,json=rootBasicExecInfo,proto3" json:"root_basic_exec_info,omitempty"`
+	RootGroupExecInfo []string        `protobuf:"bytes,12,rep,name=root_group_exec_info,json=rootGroupExecInfo" json:"root_group_exec_info,omitempty"`
+	CopExecInfo       string          `protobuf:"bytes,13,opt,name=cop_exec_info,json=copExecInfo,proto3" json:"cop_exec_info,omitempty"`
 	// memory_bytes and disk_bytes are expected to be displayed as "N/A" when they are -1,
 	// this will be consistent with the result of EXPLAIN ANALYZE.
-	MemoryBytes int64 `protobuf:"varint,16,opt,name=memory_bytes,json=memoryBytes,proto3" json:"memory_bytes,omitempty"`
-	DiskBytes   int64 `protobuf:"varint,17,opt,name=disk_bytes,json=diskBytes,proto3" json:"disk_bytes,omitempty"`
+	MemoryBytes int64 `protobuf:"varint,14,opt,name=memory_bytes,json=memoryBytes,proto3" json:"memory_bytes,omitempty"`
+	DiskBytes   int64 `protobuf:"varint,15,opt,name=disk_bytes,json=diskBytes,proto3" json:"disk_bytes,omitempty"`
 }
 
 func (m *ExplainOperator) Reset()                    { *m = ExplainOperator{} }
 func (m *ExplainOperator) String() string            { return proto.CompactTextString(m) }
 func (*ExplainOperator) ProtoMessage()               {}
 func (*ExplainOperator) Descriptor() ([]byte, []int) { return fileDescriptorExplain, []int{1} }
-
-type isExplainOperator_AccessObject interface {
-	isExplainOperator_AccessObject()
-	MarshalTo([]byte) (int, error)
-	Size() int
-}
-
-type ExplainOperator_ScanObject struct {
-	ScanObject *ScanAccessObject `protobuf:"bytes,9,opt,name=scan_object,json=scanObject,oneof"`
-}
-type ExplainOperator_DynamicPartitionObjects struct {
-	DynamicPartitionObjects *DynamicPartitionAccessObjects `protobuf:"bytes,10,opt,name=dynamic_partition_objects,json=dynamicPartitionObjects,oneof"`
-}
-type ExplainOperator_OtherObject struct {
-	OtherObject string `protobuf:"bytes,11,opt,name=other_object,json=otherObject,proto3,oneof"`
-}
-
-func (*ExplainOperator_ScanObject) isExplainOperator_AccessObject()              {}
-func (*ExplainOperator_DynamicPartitionObjects) isExplainOperator_AccessObject() {}
-func (*ExplainOperator_OtherObject) isExplainOperator_AccessObject()             {}
-
-func (m *ExplainOperator) GetAccessObject() isExplainOperator_AccessObject {
-	if m != nil {
-		return m.AccessObject
-	}
-	return nil
-}
 
 func (m *ExplainOperator) GetName() string {
 	if m != nil {
@@ -224,11 +193,11 @@ func (m *ExplainOperator) GetChildren() []*ExplainOperator {
 	return nil
 }
 
-func (m *ExplainOperator) GetDriverSide() DriverSide {
+func (m *ExplainOperator) GetLabels() []OperatorLabel {
 	if m != nil {
-		return m.DriverSide
+		return m.Labels
 	}
-	return DriverSide_empty
+	return nil
 }
 
 func (m *ExplainOperator) GetCost() float64 {
@@ -266,25 +235,11 @@ func (m *ExplainOperator) GetStoreType() StoreType {
 	return StoreType_unspecified
 }
 
-func (m *ExplainOperator) GetScanObject() *ScanAccessObject {
-	if x, ok := m.GetAccessObject().(*ExplainOperator_ScanObject); ok {
-		return x.ScanObject
+func (m *ExplainOperator) GetAccessObjects() []*AccessObject {
+	if m != nil {
+		return m.AccessObjects
 	}
 	return nil
-}
-
-func (m *ExplainOperator) GetDynamicPartitionObjects() *DynamicPartitionAccessObjects {
-	if x, ok := m.GetAccessObject().(*ExplainOperator_DynamicPartitionObjects); ok {
-		return x.DynamicPartitionObjects
-	}
-	return nil
-}
-
-func (m *ExplainOperator) GetOtherObject() string {
-	if x, ok := m.GetAccessObject().(*ExplainOperator_OtherObject); ok {
-		return x.OtherObject
-	}
-	return ""
 }
 
 func (m *ExplainOperator) GetOperatorInfo() string {
@@ -329,86 +284,147 @@ func (m *ExplainOperator) GetDiskBytes() int64 {
 	return 0
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*ExplainOperator) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _ExplainOperator_OneofMarshaler, _ExplainOperator_OneofUnmarshaler, _ExplainOperator_OneofSizer, []interface{}{
-		(*ExplainOperator_ScanObject)(nil),
-		(*ExplainOperator_DynamicPartitionObjects)(nil),
-		(*ExplainOperator_OtherObject)(nil),
-	}
+type AccessObject struct {
+	// Types that are valid to be assigned to AccessObject:
+	//	*AccessObject_ScanObject
+	//	*AccessObject_DynamicPartitionObjects
+	//	*AccessObject_OtherObject
+	AccessObject isAccessObject_AccessObject `protobuf_oneof:"access_object"`
 }
 
-func _ExplainOperator_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*ExplainOperator)
-	// access_object
-	switch x := m.AccessObject.(type) {
-	case *ExplainOperator_ScanObject:
-		_ = b.EncodeVarint(9<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.ScanObject); err != nil {
-			return err
-		}
-	case *ExplainOperator_DynamicPartitionObjects:
-		_ = b.EncodeVarint(10<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.DynamicPartitionObjects); err != nil {
-			return err
-		}
-	case *ExplainOperator_OtherObject:
-		_ = b.EncodeVarint(11<<3 | proto.WireBytes)
-		_ = b.EncodeStringBytes(x.OtherObject)
-	case nil:
-	default:
-		return fmt.Errorf("ExplainOperator.AccessObject has unexpected type %T", x)
+func (m *AccessObject) Reset()                    { *m = AccessObject{} }
+func (m *AccessObject) String() string            { return proto.CompactTextString(m) }
+func (*AccessObject) ProtoMessage()               {}
+func (*AccessObject) Descriptor() ([]byte, []int) { return fileDescriptorExplain, []int{2} }
+
+type isAccessObject_AccessObject interface {
+	isAccessObject_AccessObject()
+	MarshalTo([]byte) (int, error)
+	Size() int
+}
+
+type AccessObject_ScanObject struct {
+	ScanObject *ScanAccessObject `protobuf:"bytes,1,opt,name=scan_object,json=scanObject,oneof"`
+}
+type AccessObject_DynamicPartitionObjects struct {
+	DynamicPartitionObjects *DynamicPartitionAccessObjects `protobuf:"bytes,2,opt,name=dynamic_partition_objects,json=dynamicPartitionObjects,oneof"`
+}
+type AccessObject_OtherObject struct {
+	OtherObject string `protobuf:"bytes,3,opt,name=other_object,json=otherObject,proto3,oneof"`
+}
+
+func (*AccessObject_ScanObject) isAccessObject_AccessObject()              {}
+func (*AccessObject_DynamicPartitionObjects) isAccessObject_AccessObject() {}
+func (*AccessObject_OtherObject) isAccessObject_AccessObject()             {}
+
+func (m *AccessObject) GetAccessObject() isAccessObject_AccessObject {
+	if m != nil {
+		return m.AccessObject
 	}
 	return nil
 }
 
-func _ExplainOperator_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*ExplainOperator)
+func (m *AccessObject) GetScanObject() *ScanAccessObject {
+	if x, ok := m.GetAccessObject().(*AccessObject_ScanObject); ok {
+		return x.ScanObject
+	}
+	return nil
+}
+
+func (m *AccessObject) GetDynamicPartitionObjects() *DynamicPartitionAccessObjects {
+	if x, ok := m.GetAccessObject().(*AccessObject_DynamicPartitionObjects); ok {
+		return x.DynamicPartitionObjects
+	}
+	return nil
+}
+
+func (m *AccessObject) GetOtherObject() string {
+	if x, ok := m.GetAccessObject().(*AccessObject_OtherObject); ok {
+		return x.OtherObject
+	}
+	return ""
+}
+
+// XXX_OneofFuncs is for the internal use of the proto package.
+func (*AccessObject) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
+	return _AccessObject_OneofMarshaler, _AccessObject_OneofUnmarshaler, _AccessObject_OneofSizer, []interface{}{
+		(*AccessObject_ScanObject)(nil),
+		(*AccessObject_DynamicPartitionObjects)(nil),
+		(*AccessObject_OtherObject)(nil),
+	}
+}
+
+func _AccessObject_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
+	m := msg.(*AccessObject)
+	// access_object
+	switch x := m.AccessObject.(type) {
+	case *AccessObject_ScanObject:
+		_ = b.EncodeVarint(1<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.ScanObject); err != nil {
+			return err
+		}
+	case *AccessObject_DynamicPartitionObjects:
+		_ = b.EncodeVarint(2<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.DynamicPartitionObjects); err != nil {
+			return err
+		}
+	case *AccessObject_OtherObject:
+		_ = b.EncodeVarint(3<<3 | proto.WireBytes)
+		_ = b.EncodeStringBytes(x.OtherObject)
+	case nil:
+	default:
+		return fmt.Errorf("AccessObject.AccessObject has unexpected type %T", x)
+	}
+	return nil
+}
+
+func _AccessObject_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
+	m := msg.(*AccessObject)
 	switch tag {
-	case 9: // access_object.scan_object
+	case 1: // access_object.scan_object
 		if wire != proto.WireBytes {
 			return true, proto.ErrInternalBadWireType
 		}
 		msg := new(ScanAccessObject)
 		err := b.DecodeMessage(msg)
-		m.AccessObject = &ExplainOperator_ScanObject{msg}
+		m.AccessObject = &AccessObject_ScanObject{msg}
 		return true, err
-	case 10: // access_object.dynamic_partition_objects
+	case 2: // access_object.dynamic_partition_objects
 		if wire != proto.WireBytes {
 			return true, proto.ErrInternalBadWireType
 		}
 		msg := new(DynamicPartitionAccessObjects)
 		err := b.DecodeMessage(msg)
-		m.AccessObject = &ExplainOperator_DynamicPartitionObjects{msg}
+		m.AccessObject = &AccessObject_DynamicPartitionObjects{msg}
 		return true, err
-	case 11: // access_object.other_object
+	case 3: // access_object.other_object
 		if wire != proto.WireBytes {
 			return true, proto.ErrInternalBadWireType
 		}
 		x, err := b.DecodeStringBytes()
-		m.AccessObject = &ExplainOperator_OtherObject{x}
+		m.AccessObject = &AccessObject_OtherObject{x}
 		return true, err
 	default:
 		return false, nil
 	}
 }
 
-func _ExplainOperator_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*ExplainOperator)
+func _AccessObject_OneofSizer(msg proto.Message) (n int) {
+	m := msg.(*AccessObject)
 	// access_object
 	switch x := m.AccessObject.(type) {
-	case *ExplainOperator_ScanObject:
+	case *AccessObject_ScanObject:
 		s := proto.Size(x.ScanObject)
-		n += proto.SizeVarint(9<<3 | proto.WireBytes)
+		n += proto.SizeVarint(1<<3 | proto.WireBytes)
 		n += proto.SizeVarint(uint64(s))
 		n += s
-	case *ExplainOperator_DynamicPartitionObjects:
+	case *AccessObject_DynamicPartitionObjects:
 		s := proto.Size(x.DynamicPartitionObjects)
-		n += proto.SizeVarint(10<<3 | proto.WireBytes)
+		n += proto.SizeVarint(2<<3 | proto.WireBytes)
 		n += proto.SizeVarint(uint64(s))
 		n += s
-	case *ExplainOperator_OtherObject:
-		n += proto.SizeVarint(11<<3 | proto.WireBytes)
+	case *AccessObject_OtherObject:
+		n += proto.SizeVarint(3<<3 | proto.WireBytes)
 		n += proto.SizeVarint(uint64(len(x.OtherObject)))
 		n += len(x.OtherObject)
 	case nil:
@@ -426,7 +442,7 @@ func (m *DynamicPartitionAccessObjects) Reset()         { *m = DynamicPartitionA
 func (m *DynamicPartitionAccessObjects) String() string { return proto.CompactTextString(m) }
 func (*DynamicPartitionAccessObjects) ProtoMessage()    {}
 func (*DynamicPartitionAccessObjects) Descriptor() ([]byte, []int) {
-	return fileDescriptorExplain, []int{2}
+	return fileDescriptorExplain, []int{3}
 }
 
 func (m *DynamicPartitionAccessObjects) GetObjects() []*DynamicPartitionAccessObject {
@@ -448,7 +464,7 @@ func (m *DynamicPartitionAccessObject) Reset()         { *m = DynamicPartitionAc
 func (m *DynamicPartitionAccessObject) String() string { return proto.CompactTextString(m) }
 func (*DynamicPartitionAccessObject) ProtoMessage()    {}
 func (*DynamicPartitionAccessObject) Descriptor() ([]byte, []int) {
-	return fileDescriptorExplain, []int{3}
+	return fileDescriptorExplain, []int{4}
 }
 
 func (m *DynamicPartitionAccessObject) GetDatabase() string {
@@ -490,7 +506,7 @@ type ScanAccessObject struct {
 func (m *ScanAccessObject) Reset()                    { *m = ScanAccessObject{} }
 func (m *ScanAccessObject) String() string            { return proto.CompactTextString(m) }
 func (*ScanAccessObject) ProtoMessage()               {}
-func (*ScanAccessObject) Descriptor() ([]byte, []int) { return fileDescriptorExplain, []int{4} }
+func (*ScanAccessObject) Descriptor() ([]byte, []int) { return fileDescriptorExplain, []int{5} }
 
 func (m *ScanAccessObject) GetDatabase() string {
 	if m != nil {
@@ -529,7 +545,7 @@ type IndexAccess struct {
 func (m *IndexAccess) Reset()                    { *m = IndexAccess{} }
 func (m *IndexAccess) String() string            { return proto.CompactTextString(m) }
 func (*IndexAccess) ProtoMessage()               {}
-func (*IndexAccess) Descriptor() ([]byte, []int) { return fileDescriptorExplain, []int{5} }
+func (*IndexAccess) Descriptor() ([]byte, []int) { return fileDescriptorExplain, []int{6} }
 
 func (m *IndexAccess) GetName() string {
 	if m != nil {
@@ -555,13 +571,14 @@ func (m *IndexAccess) GetIsClusteredIndex() bool {
 func init() {
 	proto.RegisterType((*ExplainData)(nil), "tipb.ExplainData")
 	proto.RegisterType((*ExplainOperator)(nil), "tipb.ExplainOperator")
+	proto.RegisterType((*AccessObject)(nil), "tipb.AccessObject")
 	proto.RegisterType((*DynamicPartitionAccessObjects)(nil), "tipb.DynamicPartitionAccessObjects")
 	proto.RegisterType((*DynamicPartitionAccessObject)(nil), "tipb.DynamicPartitionAccessObject")
 	proto.RegisterType((*ScanAccessObject)(nil), "tipb.ScanAccessObject")
 	proto.RegisterType((*IndexAccess)(nil), "tipb.IndexAccess")
 	proto.RegisterEnum("tipb.TaskType", TaskType_name, TaskType_value)
 	proto.RegisterEnum("tipb.StoreType", StoreType_name, StoreType_value)
-	proto.RegisterEnum("tipb.DriverSide", DriverSide_name, DriverSide_value)
+	proto.RegisterEnum("tipb.OperatorLabel", OperatorLabel_name, OperatorLabel_value)
 }
 func (m *ExplainData) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
@@ -656,10 +673,22 @@ func (m *ExplainOperator) MarshalTo(dAtA []byte) (int, error) {
 			i += n
 		}
 	}
-	if m.DriverSide != 0 {
-		dAtA[i] = 0x18
+	if len(m.Labels) > 0 {
+		dAtA3 := make([]byte, len(m.Labels)*10)
+		var j2 int
+		for _, num := range m.Labels {
+			for num >= 1<<7 {
+				dAtA3[j2] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j2++
+			}
+			dAtA3[j2] = uint8(num)
+			j2++
+		}
+		dAtA[i] = 0x1a
 		i++
-		i = encodeVarintExplain(dAtA, i, uint64(m.DriverSide))
+		i = encodeVarintExplain(dAtA, i, uint64(j2))
+		i += copy(dAtA[i:], dAtA3[:j2])
 	}
 	if m.Cost != 0 {
 		dAtA[i] = 0x21
@@ -688,28 +717,33 @@ func (m *ExplainOperator) MarshalTo(dAtA []byte) (int, error) {
 		i++
 		i = encodeVarintExplain(dAtA, i, uint64(m.StoreType))
 	}
-	if m.AccessObject != nil {
-		nn2, err := m.AccessObject.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+	if len(m.AccessObjects) > 0 {
+		for _, msg := range m.AccessObjects {
+			dAtA[i] = 0x4a
+			i++
+			i = encodeVarintExplain(dAtA, i, uint64(msg.Size()))
+			n, err := msg.MarshalTo(dAtA[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
 		}
-		i += nn2
 	}
 	if len(m.OperatorInfo) > 0 {
-		dAtA[i] = 0x62
+		dAtA[i] = 0x52
 		i++
 		i = encodeVarintExplain(dAtA, i, uint64(len(m.OperatorInfo)))
 		i += copy(dAtA[i:], m.OperatorInfo)
 	}
 	if len(m.RootBasicExecInfo) > 0 {
-		dAtA[i] = 0x6a
+		dAtA[i] = 0x5a
 		i++
 		i = encodeVarintExplain(dAtA, i, uint64(len(m.RootBasicExecInfo)))
 		i += copy(dAtA[i:], m.RootBasicExecInfo)
 	}
 	if len(m.RootGroupExecInfo) > 0 {
 		for _, s := range m.RootGroupExecInfo {
-			dAtA[i] = 0x72
+			dAtA[i] = 0x62
 			i++
 			l = len(s)
 			for l >= 1<<7 {
@@ -723,59 +757,80 @@ func (m *ExplainOperator) MarshalTo(dAtA []byte) (int, error) {
 		}
 	}
 	if len(m.CopExecInfo) > 0 {
-		dAtA[i] = 0x7a
+		dAtA[i] = 0x6a
 		i++
 		i = encodeVarintExplain(dAtA, i, uint64(len(m.CopExecInfo)))
 		i += copy(dAtA[i:], m.CopExecInfo)
 	}
 	if m.MemoryBytes != 0 {
-		dAtA[i] = 0x80
-		i++
-		dAtA[i] = 0x1
+		dAtA[i] = 0x70
 		i++
 		i = encodeVarintExplain(dAtA, i, uint64(m.MemoryBytes))
 	}
 	if m.DiskBytes != 0 {
-		dAtA[i] = 0x88
-		i++
-		dAtA[i] = 0x1
+		dAtA[i] = 0x78
 		i++
 		i = encodeVarintExplain(dAtA, i, uint64(m.DiskBytes))
 	}
 	return i, nil
 }
 
-func (m *ExplainOperator_ScanObject) MarshalTo(dAtA []byte) (int, error) {
+func (m *AccessObject) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *AccessObject) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.AccessObject != nil {
+		nn4, err := m.AccessObject.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += nn4
+	}
+	return i, nil
+}
+
+func (m *AccessObject_ScanObject) MarshalTo(dAtA []byte) (int, error) {
 	i := 0
 	if m.ScanObject != nil {
-		dAtA[i] = 0x4a
+		dAtA[i] = 0xa
 		i++
 		i = encodeVarintExplain(dAtA, i, uint64(m.ScanObject.Size()))
-		n3, err := m.ScanObject.MarshalTo(dAtA[i:])
+		n5, err := m.ScanObject.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n3
+		i += n5
 	}
 	return i, nil
 }
-func (m *ExplainOperator_DynamicPartitionObjects) MarshalTo(dAtA []byte) (int, error) {
+func (m *AccessObject_DynamicPartitionObjects) MarshalTo(dAtA []byte) (int, error) {
 	i := 0
 	if m.DynamicPartitionObjects != nil {
-		dAtA[i] = 0x52
+		dAtA[i] = 0x12
 		i++
 		i = encodeVarintExplain(dAtA, i, uint64(m.DynamicPartitionObjects.Size()))
-		n4, err := m.DynamicPartitionObjects.MarshalTo(dAtA[i:])
+		n6, err := m.DynamicPartitionObjects.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n4
+		i += n6
 	}
 	return i, nil
 }
-func (m *ExplainOperator_OtherObject) MarshalTo(dAtA []byte) (int, error) {
+func (m *AccessObject_OtherObject) MarshalTo(dAtA []byte) (int, error) {
 	i := 0
-	dAtA[i] = 0x5a
+	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintExplain(dAtA, i, uint64(len(m.OtherObject)))
 	i += copy(dAtA[i:], m.OtherObject)
@@ -1016,8 +1071,12 @@ func (m *ExplainOperator) Size() (n int) {
 			n += 1 + l + sovExplain(uint64(l))
 		}
 	}
-	if m.DriverSide != 0 {
-		n += 1 + sovExplain(uint64(m.DriverSide))
+	if len(m.Labels) > 0 {
+		l = 0
+		for _, e := range m.Labels {
+			l += sovExplain(uint64(e))
+		}
+		n += 1 + sovExplain(uint64(l)) + l
 	}
 	if m.Cost != 0 {
 		n += 9
@@ -1034,8 +1093,11 @@ func (m *ExplainOperator) Size() (n int) {
 	if m.StoreType != 0 {
 		n += 1 + sovExplain(uint64(m.StoreType))
 	}
-	if m.AccessObject != nil {
-		n += m.AccessObject.Size()
+	if len(m.AccessObjects) > 0 {
+		for _, e := range m.AccessObjects {
+			l = e.Size()
+			n += 1 + l + sovExplain(uint64(l))
+		}
 	}
 	l = len(m.OperatorInfo)
 	if l > 0 {
@@ -1056,15 +1118,24 @@ func (m *ExplainOperator) Size() (n int) {
 		n += 1 + l + sovExplain(uint64(l))
 	}
 	if m.MemoryBytes != 0 {
-		n += 2 + sovExplain(uint64(m.MemoryBytes))
+		n += 1 + sovExplain(uint64(m.MemoryBytes))
 	}
 	if m.DiskBytes != 0 {
-		n += 2 + sovExplain(uint64(m.DiskBytes))
+		n += 1 + sovExplain(uint64(m.DiskBytes))
 	}
 	return n
 }
 
-func (m *ExplainOperator_ScanObject) Size() (n int) {
+func (m *AccessObject) Size() (n int) {
+	var l int
+	_ = l
+	if m.AccessObject != nil {
+		n += m.AccessObject.Size()
+	}
+	return n
+}
+
+func (m *AccessObject_ScanObject) Size() (n int) {
 	var l int
 	_ = l
 	if m.ScanObject != nil {
@@ -1073,7 +1144,7 @@ func (m *ExplainOperator_ScanObject) Size() (n int) {
 	}
 	return n
 }
-func (m *ExplainOperator_DynamicPartitionObjects) Size() (n int) {
+func (m *AccessObject_DynamicPartitionObjects) Size() (n int) {
 	var l int
 	_ = l
 	if m.DynamicPartitionObjects != nil {
@@ -1082,7 +1153,7 @@ func (m *ExplainOperator_DynamicPartitionObjects) Size() (n int) {
 	}
 	return n
 }
-func (m *ExplainOperator_OtherObject) Size() (n int) {
+func (m *AccessObject_OtherObject) Size() (n int) {
 	var l int
 	_ = l
 	l = len(m.OtherObject)
@@ -1426,23 +1497,66 @@ func (m *ExplainOperator) Unmarshal(dAtA []byte) error {
 			}
 			iNdEx = postIndex
 		case 3:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field DriverSide", wireType)
-			}
-			m.DriverSide = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowExplain
+			if wireType == 0 {
+				var v OperatorLabel
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowExplain
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					v |= (OperatorLabel(b) & 0x7F) << shift
+					if b < 0x80 {
+						break
+					}
 				}
-				if iNdEx >= l {
+				m.Labels = append(m.Labels, v)
+			} else if wireType == 2 {
+				var packedLen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowExplain
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					packedLen |= (int(b) & 0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if packedLen < 0 {
+					return ErrInvalidLengthExplain
+				}
+				postIndex := iNdEx + packedLen
+				if postIndex > l {
 					return io.ErrUnexpectedEOF
 				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				m.DriverSide |= (DriverSide(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
+				for iNdEx < postIndex {
+					var v OperatorLabel
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowExplain
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						v |= (OperatorLabel(b) & 0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					m.Labels = append(m.Labels, v)
 				}
+			} else {
+				return fmt.Errorf("proto: wrong wireType = %d for field Labels", wireType)
 			}
 		case 4:
 			if wireType != 1 {
@@ -1525,6 +1639,241 @@ func (m *ExplainOperator) Unmarshal(dAtA []byte) error {
 			}
 		case 9:
 			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AccessObjects", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowExplain
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthExplain
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.AccessObjects = append(m.AccessObjects, &AccessObject{})
+			if err := m.AccessObjects[len(m.AccessObjects)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 10:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field OperatorInfo", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowExplain
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthExplain
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.OperatorInfo = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 11:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RootBasicExecInfo", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowExplain
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthExplain
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.RootBasicExecInfo = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 12:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RootGroupExecInfo", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowExplain
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthExplain
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.RootGroupExecInfo = append(m.RootGroupExecInfo, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 13:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CopExecInfo", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowExplain
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthExplain
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.CopExecInfo = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 14:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MemoryBytes", wireType)
+			}
+			m.MemoryBytes = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowExplain
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.MemoryBytes |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 15:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DiskBytes", wireType)
+			}
+			m.DiskBytes = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowExplain
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.DiskBytes |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipExplain(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthExplain
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *AccessObject) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowExplain
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: AccessObject: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: AccessObject: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field ScanObject", wireType)
 			}
 			var msglen int
@@ -1553,9 +1902,9 @@ func (m *ExplainOperator) Unmarshal(dAtA []byte) error {
 			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.AccessObject = &ExplainOperator_ScanObject{v}
+			m.AccessObject = &AccessObject_ScanObject{v}
 			iNdEx = postIndex
-		case 10:
+		case 2:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field DynamicPartitionObjects", wireType)
 			}
@@ -1585,9 +1934,9 @@ func (m *ExplainOperator) Unmarshal(dAtA []byte) error {
 			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.AccessObject = &ExplainOperator_DynamicPartitionObjects{v}
+			m.AccessObject = &AccessObject_DynamicPartitionObjects{v}
 			iNdEx = postIndex
-		case 11:
+		case 3:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field OtherObject", wireType)
 			}
@@ -1614,162 +1963,8 @@ func (m *ExplainOperator) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.AccessObject = &ExplainOperator_OtherObject{string(dAtA[iNdEx:postIndex])}
+			m.AccessObject = &AccessObject_OtherObject{string(dAtA[iNdEx:postIndex])}
 			iNdEx = postIndex
-		case 12:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field OperatorInfo", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowExplain
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthExplain
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.OperatorInfo = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
-		case 13:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field RootBasicExecInfo", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowExplain
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthExplain
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.RootBasicExecInfo = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
-		case 14:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field RootGroupExecInfo", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowExplain
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthExplain
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.RootGroupExecInfo = append(m.RootGroupExecInfo, string(dAtA[iNdEx:postIndex]))
-			iNdEx = postIndex
-		case 15:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field CopExecInfo", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowExplain
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthExplain
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.CopExecInfo = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
-		case 16:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field MemoryBytes", wireType)
-			}
-			m.MemoryBytes = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowExplain
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				m.MemoryBytes |= (int64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-		case 17:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field DiskBytes", wireType)
-			}
-			m.DiskBytes = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowExplain
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				m.DiskBytes |= (int64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipExplain(dAtA[iNdEx:])
@@ -2433,61 +2628,63 @@ var (
 func init() { proto.RegisterFile("explain.proto", fileDescriptorExplain) }
 
 var fileDescriptorExplain = []byte{
-	// 889 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x95, 0x51, 0x6f, 0x1b, 0x45,
-	0x10, 0xc7, 0x7d, 0xb1, 0x53, 0xdb, 0x73, 0x76, 0x7c, 0x59, 0x25, 0x70, 0xa9, 0xa8, 0x65, 0x1c,
-	0x21, 0xa5, 0x29, 0x72, 0xd5, 0xf2, 0x02, 0x12, 0x3c, 0x34, 0x4d, 0x21, 0x95, 0x90, 0x5a, 0x5d,
-	0xf2, 0x8a, 0x4e, 0x7b, 0xbb, 0x13, 0x7b, 0xf1, 0xf9, 0xf6, 0xb4, 0xbb, 0x4e, 0xe2, 0x8f, 0xc1,
-	0x13, 0x7c, 0x24, 0x24, 0x5e, 0xf8, 0x08, 0x28, 0x7c, 0x04, 0xbe, 0x00, 0xda, 0xdd, 0x3b, 0xc7,
-	0x44, 0x28, 0x95, 0xfa, 0x36, 0x37, 0xff, 0xdf, 0xcc, 0x8e, 0x67, 0x76, 0xc7, 0xd0, 0xc7, 0x9b,
-	0x32, 0xa7, 0xa2, 0x98, 0x94, 0x4a, 0x1a, 0x49, 0x5a, 0x46, 0x94, 0xd9, 0xe3, 0xbd, 0xa9, 0x9c,
-	0x4a, 0xe7, 0x78, 0x6e, 0x2d, 0xaf, 0x8d, 0xff, 0x08, 0x20, 0x7c, 0xe3, 0xe9, 0x53, 0x6a, 0x28,
-	0x79, 0x0a, 0xad, 0x05, 0x15, 0x45, 0x1c, 0x8c, 0x82, 0xa3, 0xf0, 0xe5, 0xfe, 0xc4, 0x86, 0x4e,
-	0x2a, 0xe0, 0x5d, 0x89, 0x8a, 0x1a, 0xa9, 0x12, 0x87, 0x58, 0x94, 0x19, 0xd4, 0xf1, 0xd6, 0xa8,
-	0xf9, 0x00, 0x6a, 0x11, 0xf2, 0x25, 0x90, 0x6b, 0x61, 0x66, 0xa9, 0x5a, 0x16, 0x46, 0x2c, 0x30,
-	0xd5, 0x86, 0x1a, 0x1d, 0x37, 0x47, 0xc1, 0x51, 0x27, 0x89, 0xac, 0x92, 0x78, 0xe1, 0xdc, 0xfa,
-	0xc9, 0xd7, 0x70, 0xc0, 0x85, 0x66, 0x54, 0x71, 0xe4, 0x29, 0x5f, 0x62, 0x6a, 0x64, 0x6a, 0xa4,
-	0x4c, 0x73, 0x59, 0x4c, 0xe3, 0x96, 0x0b, 0xda, 0x5f, 0x03, 0xa7, 0x4b, 0xbc, 0x90, 0x17, 0x52,
-	0xfe, 0x28, 0x8b, 0xe9, 0xf8, 0x9f, 0x6d, 0x18, 0xdc, 0xab, 0x80, 0x10, 0x68, 0x15, 0x74, 0x81,
-	0xee, 0x17, 0x75, 0x13, 0x67, 0x93, 0x17, 0xd0, 0x61, 0x33, 0x91, 0x73, 0x85, 0xc5, 0xc3, 0xe5,
-	0xaf, 0x31, 0xf2, 0x02, 0x42, 0xae, 0xc4, 0x15, 0xaa, 0x54, 0x0b, 0x8e, 0xae, 0xf6, 0x9d, 0x97,
-	0x91, 0x8f, 0x3a, 0x75, 0xc2, 0xb9, 0xe0, 0x98, 0x00, 0x5f, 0xdb, 0xf6, 0x64, 0x26, 0xb5, 0x71,
-	0x25, 0x07, 0x89, 0xb3, 0xc9, 0x01, 0x74, 0x50, 0x9b, 0x54, 0xc9, 0x6b, 0x1d, 0x6f, 0x3b, 0x7f,
-	0x1b, 0xb5, 0x49, 0xe4, 0xb5, 0xb6, 0x12, 0x65, 0x95, 0xf4, 0x68, 0x14, 0x1c, 0xb5, 0x92, 0x36,
-	0x65, 0x5e, 0x7a, 0x06, 0x5d, 0x43, 0xf5, 0x3c, 0x35, 0xab, 0x12, 0xe3, 0xb6, 0x3b, 0x7a, 0xc7,
-	0x1f, 0x7d, 0x41, 0xf5, 0xfc, 0x62, 0x55, 0x62, 0xd2, 0x31, 0x95, 0x45, 0x26, 0x00, 0xda, 0x48,
-	0x85, 0x9e, 0xee, 0x38, 0x7a, 0xe0, 0xe9, 0x73, 0xeb, 0x77, 0x78, 0x57, 0xd7, 0x26, 0xf9, 0x06,
-	0x42, 0xcd, 0x68, 0x91, 0xca, 0xec, 0x67, 0x64, 0x26, 0xee, 0xba, 0xc9, 0x7f, 0x52, 0x05, 0x30,
-	0x5a, 0xbc, 0x62, 0x0c, 0xb5, 0x7e, 0xe7, 0xd4, 0xb3, 0x46, 0x02, 0x16, 0xf6, 0x5f, 0x84, 0xc2,
-	0x01, 0x5f, 0x15, 0x74, 0x21, 0x58, 0x5a, 0x52, 0x65, 0x84, 0x11, 0xb2, 0xce, 0xa3, 0x63, 0x70,
-	0x89, 0x0e, 0xab, 0x16, 0x79, 0xec, 0x7d, 0x4d, 0x6d, 0x26, 0xd5, 0x67, 0x8d, 0xe4, 0x53, 0x7e,
-	0x0f, 0xa8, 0x24, 0x72, 0x08, 0x3d, 0x69, 0x66, 0xa8, 0xea, 0xf2, 0x42, 0x3b, 0xc6, 0xb3, 0x46,
-	0x12, 0x3a, 0x6f, 0x55, 0xc7, 0x21, 0xf4, 0x65, 0x35, 0xb2, 0x54, 0x14, 0x97, 0x32, 0xee, 0xb9,
-	0x61, 0xf7, 0x6a, 0xe7, 0xdb, 0xe2, 0x52, 0x92, 0xe7, 0xb0, 0xa7, 0xa4, 0x34, 0x69, 0x46, 0xb5,
-	0x60, 0x29, 0xde, 0x20, 0xf3, 0x6c, 0xdf, 0xb1, 0xbb, 0x56, 0x3b, 0xb1, 0xd2, 0x9b, 0x1b, 0x64,
-	0xff, 0x09, 0x98, 0x2a, 0xb9, 0x2c, 0x37, 0x02, 0x76, 0x46, 0xcd, 0x3a, 0xe0, 0x07, 0x2b, 0xad,
-	0x03, 0xc6, 0xd0, 0x67, 0x72, 0x93, 0x1c, 0xb8, 0xd4, 0x21, 0x93, 0x77, 0xcc, 0xe7, 0xd0, 0x5b,
-	0xe0, 0x42, 0xaa, 0x55, 0x9a, 0xad, 0xec, 0xeb, 0x89, 0x46, 0xc1, 0x51, 0x33, 0x09, 0xbd, 0xef,
-	0xc4, 0xba, 0xc8, 0x13, 0x00, 0x2e, 0xf4, 0xbc, 0x02, 0x76, 0x1d, 0xd0, 0xb5, 0x1e, 0x27, 0x9f,
-	0x0c, 0xa0, 0x4f, 0x5d, 0xf7, 0xaa, 0x96, 0x8c, 0x7f, 0x82, 0x27, 0x0f, 0xb6, 0x97, 0x7c, 0x0b,
-	0xed, 0x7a, 0x28, 0x81, 0xbb, 0xed, 0xe3, 0x0f, 0x0f, 0x25, 0xa9, 0x43, 0xc6, 0xbf, 0x06, 0xf0,
-	0xd9, 0x43, 0x24, 0x79, 0x0c, 0x1d, 0x4e, 0x0d, 0xcd, 0xa8, 0xae, 0x5f, 0xd9, 0xfa, 0x9b, 0xec,
-	0xc1, 0xb6, 0xa1, 0x59, 0x8e, 0xf1, 0x96, 0x13, 0xfc, 0x07, 0xf9, 0x02, 0x76, 0x68, 0x9e, 0xdf,
-	0xdd, 0x99, 0x7a, 0x17, 0xf4, 0x69, 0x9e, 0xaf, 0xcf, 0xd0, 0x64, 0x08, 0xb0, 0x81, 0xb4, 0x5c,
-	0xdb, 0x37, 0x3c, 0xe3, 0x5f, 0x02, 0x88, 0xee, 0xdf, 0xd0, 0x8f, 0xa8, 0xe6, 0x19, 0xb4, 0x45,
-	0xc1, 0xf1, 0x06, 0x6d, 0x19, 0xb6, 0x3d, 0xbb, 0xbe, 0x3d, 0x6f, 0xad, 0xd3, 0xe7, 0x4e, 0x6a,
-	0xe2, 0x83, 0x35, 0x31, 0x08, 0x37, 0xe2, 0xfe, 0x77, 0xfb, 0xb8, 0xbd, 0x90, 0xfb, 0xc5, 0xd9,
-	0x4d, 0x9c, 0x6d, 0x37, 0xa4, 0xd0, 0x29, 0xcb, 0x97, 0xda, 0xa0, 0x42, 0x9e, 0xba, 0xe3, 0xea,
-	0x0d, 0x29, 0xf4, 0xeb, 0x5a, 0x70, 0xb9, 0x8f, 0x5f, 0x41, 0xa7, 0x7e, 0xf8, 0x24, 0x84, 0xf6,
-	0xb2, 0x98, 0x17, 0xf2, 0xba, 0x88, 0x1a, 0xa4, 0x03, 0x2d, 0x7b, 0x2d, 0xa3, 0x80, 0xb4, 0xa1,
-	0xc9, 0x64, 0x19, 0x6d, 0x91, 0x1e, 0x74, 0x32, 0x6a, 0xd8, 0xec, 0xb5, 0x2c, 0xa3, 0xa6, 0x75,
-	0x2f, 0xca, 0x32, 0x6a, 0x1d, 0x7f, 0x07, 0xdd, 0xf5, 0x36, 0x20, 0x03, 0x08, 0x97, 0x85, 0x2e,
-	0x91, 0x89, 0x4b, 0x81, 0xdc, 0xe7, 0x31, 0x82, 0x67, 0x51, 0xe0, 0xad, 0xf9, 0x55, 0xb4, 0x65,
-	0x0f, 0x32, 0xe2, 0x32, 0xa7, 0x7a, 0x16, 0x35, 0x8f, 0xbf, 0x07, 0xb8, 0xdb, 0x7a, 0xa4, 0x0b,
-	0xdb, 0xb8, 0x28, 0xcd, 0x2a, 0x6a, 0x58, 0x33, 0x5b, 0x8a, 0x9c, 0x47, 0x81, 0x35, 0x4b, 0x25,
-	0x33, 0x8c, 0xb6, 0x6c, 0x16, 0x8d, 0xc8, 0xa3, 0x26, 0xe9, 0x43, 0x57, 0x21, 0x5b, 0x2a, 0x2d,
-	0xae, 0x30, 0x6a, 0x9d, 0x3c, 0xfd, 0xfd, 0x76, 0x18, 0xfc, 0x79, 0x3b, 0x0c, 0xfe, 0xba, 0x1d,
-	0x06, 0xbf, 0xfd, 0x3d, 0x6c, 0xc0, 0x3e, 0x93, 0x8b, 0x49, 0x29, 0x8a, 0x29, 0xa3, 0xe5, 0xc4,
-	0x16, 0xe1, 0x86, 0xf1, 0x3e, 0xc8, 0x1e, 0xb9, 0x7f, 0xac, 0xaf, 0xfe, 0x0d, 0x00, 0x00, 0xff,
-	0xff, 0xc2, 0xe0, 0x1a, 0x62, 0xde, 0x06, 0x00, 0x00,
+	// 918 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x95, 0x41, 0x6f, 0xdb, 0x36,
+	0x14, 0xc7, 0xcd, 0x58, 0x89, 0xad, 0x27, 0xcb, 0x56, 0xb8, 0x64, 0x73, 0x8a, 0xd5, 0xf0, 0x5c,
+	0x0c, 0x70, 0x93, 0xc1, 0xc5, 0xb2, 0xcb, 0x0a, 0x6c, 0x87, 0xa6, 0x29, 0x96, 0x02, 0x05, 0x5a,
+	0x28, 0xb9, 0xec, 0x30, 0x08, 0x14, 0xc5, 0xd8, 0x9c, 0x65, 0x52, 0x10, 0xe9, 0x26, 0xfe, 0x18,
+	0x3b, 0x6d, 0x1f, 0x69, 0xc0, 0x2e, 0x3b, 0xec, 0x03, 0x0c, 0xd9, 0x17, 0x19, 0x48, 0x4a, 0x8e,
+	0x13, 0x0c, 0x09, 0xb0, 0x1b, 0xf9, 0xff, 0xff, 0xde, 0xe3, 0xf3, 0xa3, 0xf8, 0x0c, 0x21, 0xbb,
+	0x2e, 0x72, 0xc2, 0xc5, 0xa4, 0x28, 0xa5, 0x96, 0xd8, 0xd3, 0xbc, 0x48, 0x9f, 0xec, 0x4d, 0xe5,
+	0x54, 0x5a, 0xe1, 0x85, 0x59, 0x39, 0x6f, 0xf4, 0x07, 0x82, 0xe0, 0x8d, 0xa3, 0x4f, 0x89, 0x26,
+	0xf8, 0x39, 0x78, 0x0b, 0xc2, 0x45, 0x1f, 0x0d, 0xd1, 0x38, 0x38, 0xde, 0x9f, 0x98, 0xd0, 0x49,
+	0x05, 0xbc, 0x2f, 0x58, 0x49, 0xb4, 0x2c, 0x63, 0x8b, 0x18, 0x94, 0x6a, 0xa6, 0xfa, 0x5b, 0xc3,
+	0xe6, 0x03, 0xa8, 0x41, 0xf0, 0x57, 0x80, 0xaf, 0xb8, 0x9e, 0x25, 0xe5, 0x52, 0x68, 0xbe, 0x60,
+	0x89, 0xd2, 0x44, 0xab, 0x7e, 0x73, 0x88, 0xc6, 0xed, 0x38, 0x32, 0x4e, 0xec, 0x8c, 0x73, 0xa3,
+	0xe3, 0x6f, 0xe1, 0x20, 0xe3, 0x8a, 0x92, 0x32, 0x63, 0x59, 0x92, 0x2d, 0x59, 0xa2, 0x65, 0xa2,
+	0xa5, 0x4c, 0x72, 0x29, 0xa6, 0x7d, 0xcf, 0x06, 0xed, 0xaf, 0x81, 0xd3, 0x25, 0xbb, 0x90, 0x17,
+	0x52, 0xbe, 0x93, 0x62, 0x3a, 0xfa, 0xcb, 0x83, 0xde, 0xbd, 0x0a, 0x30, 0x06, 0x4f, 0x90, 0x05,
+	0xb3, 0xbf, 0xc8, 0x8f, 0xed, 0x1a, 0x7f, 0x0d, 0x6d, 0x3a, 0xe3, 0x79, 0x56, 0x32, 0xf1, 0x70,
+	0xf9, 0x6b, 0x0c, 0x1f, 0xc1, 0x4e, 0x4e, 0x52, 0x96, 0x9b, 0xb2, 0x9b, 0xe3, 0xee, 0xf1, 0x27,
+	0x2e, 0xa0, 0x26, 0xdf, 0x19, 0x2f, 0xae, 0x10, 0x73, 0x26, 0x95, 0x4a, 0xdb, 0x62, 0x51, 0x6c,
+	0xd7, 0xf8, 0x00, 0xda, 0x4c, 0xe9, 0xa4, 0x94, 0x57, 0xaa, 0xbf, 0x6d, 0xf5, 0x16, 0x53, 0x3a,
+	0x96, 0x57, 0xca, 0x58, 0x84, 0x56, 0xd6, 0xce, 0x10, 0x8d, 0xbd, 0xb8, 0x45, 0xa8, 0xb3, 0x8e,
+	0xc0, 0xd7, 0x44, 0xcd, 0x13, 0xbd, 0x2a, 0x58, 0xbf, 0x35, 0x44, 0xe3, 0xee, 0x71, 0xd7, 0x9d,
+	0x7c, 0x41, 0xd4, 0xfc, 0x62, 0x55, 0xb0, 0xb8, 0xad, 0xab, 0x15, 0x9e, 0x00, 0x28, 0x2d, 0x4b,
+	0xe6, 0xe8, 0xb6, 0xa5, 0x7b, 0x8e, 0x3e, 0x37, 0xba, 0xc5, 0x7d, 0x55, 0x2f, 0xf1, 0x4b, 0xe8,
+	0x12, 0x4a, 0x99, 0x52, 0x89, 0x4c, 0x7f, 0x66, 0x54, 0xab, 0xbe, 0x6f, 0x9b, 0x81, 0x5d, 0xcc,
+	0x2b, 0xeb, 0xbd, 0xb7, 0x56, 0x1c, 0x92, 0x8d, 0x9d, 0xc2, 0xcf, 0x20, 0x94, 0xd5, 0x4f, 0x4f,
+	0xb8, 0xb8, 0x94, 0x7d, 0xb0, 0xed, 0xed, 0xd4, 0xe2, 0x5b, 0x71, 0x29, 0xf1, 0x0b, 0xd8, 0x2b,
+	0xa5, 0xd4, 0x49, 0x4a, 0x14, 0xa7, 0x09, 0xbb, 0x66, 0xd4, 0xb1, 0x81, 0x65, 0x77, 0x8d, 0x77,
+	0x62, 0xac, 0x37, 0xd7, 0x8c, 0xde, 0x09, 0x98, 0x96, 0x72, 0x59, 0x6c, 0x04, 0x74, 0x86, 0xcd,
+	0x3a, 0xe0, 0x07, 0x63, 0xad, 0x03, 0x46, 0x10, 0x52, 0xb9, 0x49, 0x86, 0x36, 0x75, 0x40, 0xe5,
+	0x2d, 0xf3, 0x05, 0x74, 0x16, 0x6c, 0x21, 0xcb, 0x55, 0x92, 0xae, 0xcc, 0xf7, 0xda, 0x1d, 0xa2,
+	0x71, 0x33, 0x0e, 0x9c, 0x76, 0x62, 0x24, 0xfc, 0x14, 0x20, 0xe3, 0x6a, 0x5e, 0x01, 0x3d, 0x0b,
+	0xf8, 0x46, 0xb1, 0xf6, 0xe8, 0x06, 0x41, 0x67, 0xb3, 0x19, 0xf8, 0x25, 0x04, 0x8a, 0x12, 0x51,
+	0xb5, 0xad, 0x7a, 0x2c, 0x9f, 0x56, 0x9d, 0xa6, 0x44, 0x6c, 0xc2, 0x67, 0x8d, 0x18, 0x0c, 0x5c,
+	0x85, 0x12, 0x38, 0xc8, 0x56, 0x82, 0x2c, 0x38, 0x4d, 0x0a, 0x52, 0x6a, 0xae, 0xb9, 0x14, 0xeb,
+	0xf6, 0x6f, 0xd9, 0x44, 0xcf, 0x5c, 0xa2, 0x53, 0x87, 0x7d, 0xa8, 0xa9, 0xcd, 0xa4, 0xea, 0xac,
+	0x11, 0x7f, 0x96, 0xdd, 0x03, 0x6e, 0xef, 0xa6, 0x23, 0xf5, 0x8c, 0x95, 0x75, 0x79, 0xe6, 0x9d,
+	0xf9, 0x67, 0x8d, 0x38, 0xb0, 0xaa, 0xa3, 0x4e, 0x7a, 0x10, 0xde, 0xb9, 0xfb, 0xd1, 0x4f, 0xf0,
+	0xf4, 0xc1, 0x13, 0xf1, 0x77, 0xd0, 0xaa, 0xeb, 0x44, 0xf6, 0x33, 0x19, 0x3d, 0x5e, 0x67, 0x5c,
+	0x87, 0x8c, 0x7e, 0x45, 0xf0, 0xf9, 0x43, 0x24, 0x7e, 0x02, 0xed, 0x8c, 0x68, 0x92, 0x12, 0x55,
+	0xbf, 0xd5, 0xf5, 0x1e, 0xef, 0xc1, 0xb6, 0x26, 0x69, 0xce, 0x6c, 0x83, 0xfc, 0xd8, 0x6d, 0xf0,
+	0x97, 0xd0, 0x25, 0x79, 0x7e, 0xdb, 0xc6, 0x7a, 0xa2, 0x84, 0x24, 0xcf, 0xd7, 0x67, 0x28, 0x3c,
+	0x00, 0xd8, 0x40, 0x3c, 0xfb, 0x29, 0x6d, 0x28, 0xa3, 0x5f, 0x10, 0x44, 0xf7, 0x2f, 0xed, 0x7f,
+	0x54, 0x73, 0x04, 0x2d, 0x2e, 0x32, 0x76, 0xcd, 0xdc, 0x84, 0x08, 0x8e, 0x77, 0x5d, 0x7b, 0xde,
+	0x1a, 0xd1, 0xe5, 0x8e, 0x6b, 0xe2, 0xd1, 0x9a, 0x28, 0x04, 0x1b, 0x71, 0xff, 0x39, 0xc3, 0xec,
+	0x8c, 0xc9, 0xdd, 0xf8, 0xf5, 0x63, 0xbb, 0x36, 0x73, 0x96, 0xab, 0x84, 0xe6, 0x4b, 0xa5, 0x59,
+	0xc9, 0xb2, 0xc4, 0x1e, 0x57, 0xcf, 0x59, 0xae, 0x5e, 0xd7, 0x86, 0xcd, 0x7d, 0xf8, 0x0a, 0xda,
+	0xf5, 0x10, 0xc1, 0x01, 0xb4, 0x96, 0x62, 0x2e, 0xe4, 0x95, 0x88, 0x1a, 0xb8, 0x0d, 0x9e, 0x79,
+	0x6a, 0x11, 0xc2, 0x2d, 0x68, 0x52, 0x59, 0x44, 0x5b, 0xb8, 0x03, 0xed, 0x94, 0x68, 0x3a, 0x7b,
+	0x2d, 0x8b, 0xa8, 0x69, 0xe4, 0x45, 0x51, 0x44, 0xde, 0xe1, 0xf7, 0xe0, 0xaf, 0x27, 0x0b, 0xee,
+	0x41, 0xb0, 0x14, 0xaa, 0x60, 0x94, 0x5f, 0x72, 0x96, 0xb9, 0x3c, 0x9a, 0x67, 0x69, 0x84, 0xdc,
+	0x6a, 0xfe, 0x31, 0xda, 0x32, 0x07, 0x69, 0x7e, 0x99, 0x13, 0x35, 0x8b, 0x9a, 0x87, 0x3f, 0x42,
+	0x78, 0x67, 0x80, 0x62, 0x1f, 0xb6, 0xd9, 0xa2, 0xd0, 0xab, 0xa8, 0x81, 0x43, 0xf0, 0xd3, 0x25,
+	0xcf, 0xb3, 0x73, 0x9e, 0xb1, 0x08, 0x99, 0x6d, 0x51, 0xca, 0x94, 0xd9, 0xad, 0xad, 0x47, 0x31,
+	0x96, 0x99, 0x6b, 0x8e, 0x9a, 0x78, 0x17, 0xc2, 0x92, 0xd1, 0x65, 0xa9, 0xf8, 0x47, 0x66, 0x25,
+	0xef, 0xe4, 0xf9, 0xef, 0x37, 0x03, 0xf4, 0xe7, 0xcd, 0x00, 0xfd, 0x7d, 0x33, 0x40, 0xbf, 0xfd,
+	0x33, 0x68, 0xc0, 0x3e, 0x95, 0x8b, 0x49, 0xc1, 0xc5, 0x94, 0x92, 0x62, 0x62, 0xea, 0xb2, 0xf7,
+	0xf3, 0x01, 0xa5, 0x3b, 0xf6, 0xaf, 0xf0, 0x9b, 0x7f, 0x03, 0x00, 0x00, 0xff, 0xff, 0x1e, 0x6a,
+	0x5b, 0xf1, 0x37, 0x07, 0x00, 0x00,
 }

--- a/proto/explain.proto
+++ b/proto/explain.proto
@@ -27,7 +27,7 @@ message ExplainOperator {
     string name = 1;
     repeated ExplainOperator children = 2;
 
-    DriverSide driver_side = 3;
+    repeated OperatorLabel labels = 3;
 
     // the cost of the current operator
     double cost = 4;
@@ -39,21 +39,25 @@ message ExplainOperator {
     StoreType store_type = 8;
 
     // The XXXReader/XXXScan/MemTable/PointGet/BatchPointGet may use this
-    oneof access_object {
-        ScanAccessObject scan_object = 9;
-        DynamicPartitionAccessObjects dynamic_partition_objects = 10;
-        string other_object = 11;
-    }
+    repeated AccessObject access_objects = 9;
 
-    string operator_info = 12;
-    string root_basic_exec_info = 13;
-    repeated string root_group_exec_info = 14;
-    string cop_exec_info = 15;
+    string operator_info = 10;
+    string root_basic_exec_info = 11;
+    repeated string root_group_exec_info = 12;
+    string cop_exec_info = 13;
 
     // memory_bytes and disk_bytes are expected to be displayed as "N/A" when they are -1,
     // this will be consistent with the result of EXPLAIN ANALYZE.
-    int64 memory_bytes = 16;
-    int64 disk_bytes = 17;
+    int64 memory_bytes = 14;
+    int64 disk_bytes = 15;
+}
+
+message AccessObject {
+    oneof access_object {
+        ScanAccessObject scan_object = 1;
+        DynamicPartitionAccessObjects dynamic_partition_objects = 2;
+        string other_object = 3;
+    }
 }
 
 message DynamicPartitionAccessObjects {
@@ -94,13 +98,14 @@ enum StoreType {
     unspecified = 0;
     tidb = 1;
     tikv = 2;
-    tiflash =3;
+    tiflash = 3;
 }
 
-enum DriverSide {
+enum OperatorLabel {
+    // empty is not expected to be used.
     empty = 0;
-    build = 1;
-    probe = 2;
-    seed = 3;
-    recursive = 4;
+    buildSide = 1;
+    probeSide = 2;
+    seedPart = 3;
+    recursivePart = 4;
 }


### PR DESCRIPTION

### What problem does this PR solve?

ref https://github.com/pingcap/tidb/issues/35889

### What is changed and how it works?


What's Changed:

Modify the definition of the binary plan. Because we haven't used this in tidb and the dashboard, so we can modify it safely.

Two places are changed:
1. "DriverSide" is renamed to "Label" to reduce misunderstanding. And it's also changed to "repeated" in case there may be multiple labels in the future.
2. "AccessObject" is also changed to "repeated" in case there may be multiple "AccessObject" in the future. Because of the limitation of protobuf, I also have to extract the definition of "AccessObject" out of "ExplainOperator".


### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch
