### PR TITLE
Fix cpp include header path

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -85,7 +85,6 @@ set_source_files_properties(${CLEAN_PROTO_DEFS} ${PROTO_SRCS} ${PROTO_HDRS} PROP
 
 add_library(tipb ${PROTO_SRCS} ${PROTO_HDRS})
 target_include_directories(tipb PUBLIC
-    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}
     ${Protobuf_INCLUDE_DIR}
-    ${PROTO_OUTPUT_DIR}
 )


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <tshent@qq.com>

<!-- Thank you for contributing to tipb!

PR Title Format:
1. [module]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
In https://github.com/pingcap/tipb/pull/268, we generate the .pb.h, .pb.cc files under "${CMAKE_CURRENT_BINARY_DIR}/tipb", and also set the include path to it. That's not right because we include headers by using `#include <tipb/expression.pb.h>` in C++ code.

Ref:
* https://github.com/pingcap/tiflash/pull/5589
* https://ci.pingcap.net/blue/organizations/jenkins/tiflash-build-common/detail/tiflash-build-common/10853/pipeline/

### What is changed and how it works?

Use "${CMAKE_CURRENT_BINARY_DIR}" instead of "${CMAKE_CURRENT_BINARY_DIR}/tipb" as the include path

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch
