### PR TITLE
Fix cpp cmakefile incorrect file path issue

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -46,7 +46,7 @@ foreach (F ${PROTO_DEFS})
         OUTPUT "${PROTO_DEF_TMP_DIR}/${FIL_WE}.proto"
         WORKING_DIRECTORY ${PROTO_DEF_DIR}
         COMMAND cp ${ABS_FIL} ${PROTO_DEF_TMP_DIR}/${FIL_WE}.proto
-        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/../generate-cpp.sh"
+        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/../scripts/generate-cpp.sh"
         ARGS clean ${PROTO_DEF_TMP_DIR}/${FIL_WE}.proto
         DEPENDS ${ABS_FIL}
         COMMENT "Generating clean proto file on ${ABS_FIL}"


### PR DESCRIPTION
<!-- Thank you for contributing to tipb!

PR Title Format:
1. [module]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
In https://github.com/pingcap/tipb/pull/347, generate-cpp.sh path is changed, the CMakefile under cpp dir should be updated also.
Problem Summary:
### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch
