### PR TITLE
ci: pin GITHUB_TOKEN to read-only for unit tests

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -2,6 +2,9 @@ name: "Unit Test"
 
 on: [ push,pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   go:
     name: Test go generation


### PR DESCRIPTION
This change declares explicit `permissions: contents: read` on the Unit Test workflow.

GitHub Actions grants the GITHUB_TOKEN broad read/write scopes by default. Since this workflow only checks out the repository and runs protobuf codegen verification, it only needs read access. Restricting token scope reduces the blast radius in case any action in the pipeline were compromised.

For background on why this matters: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token